### PR TITLE
Bug/Unified configuration in the .lpi Lazarus project files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2025-06-26
+
+### Added
+- User-friendly scripts for building and cleaning all example projects at once:
+  - `compile-all-examples.sh` and `clean-all-examples.sh` (Linux/macOS)
+  - `compile-all-examples.ps1` and `clean-all-examples.ps1` (Windows)
+- Emoji/status output in all scripts for a more pleasant user experience.
+
+### Improved
+- All example project outputs are now standardized to the `example-bin/` folder for easier access and cleanup.
+- Updated `README.md` to document the new scripts and output location for examples.
+
 ## [1.1.2] - 2025-06-20
 
 ### Improved

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Command-Line Interface Framework for Free Pascal 🚀
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/version-1.1.2-blue.svg)](https://github.com/ikelaiah/cli-fp/releases)
+[![Version](https://img.shields.io/badge/version-1.1.3-blue.svg)](https://github.com/ikelaiah/cli-fp/releases)
 [![Free Pascal](https://img.shields.io/badge/Free%20Pascal-3.2.2-blue.svg)](https://www.freepascal.org/)
 [![Lazarus](https://img.shields.io/badge/Lazarus-4.0-orange.svg)](https://www.lazarus-ide.org/)
 [![GitHub stars](https://img.shields.io/github/stars/ikelaiah/cli-fp?style=social)](https://github.com/ikelaiah/cli-fp/stargazers)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Combines Free Pascal's speed and reliability with professional-grade features. T
 No complex build system needed! Just:
 
 > **Note:** All example builds output their executables and units to the `example-bin/` folder in the repository root for easy access and cleanup.
+>
+> **Tip:** To build or clean all example projects at once, use the provided scripts:
+>
+> - On **Linux/macOS**: `./compile-all-examples.sh` and `./clean-all-examples.sh`
+> - On **Windows**: `./compile-all-examples.ps1` and `./clean-all-examples.ps1`
+
 
 ```bash
 # Clone the repository

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Combines Free Pascal's speed and reliability with professional-grade features. T
 
 No complex build system needed! Just:
 
+> **Note:** All example builds output their executables and units to the `example-bin/` folder in the repository root for easy access and cleanup.
+
 ```bash
 # Clone the repository
 git clone https://github.com/ikelaiah/cli-fp.git

--- a/clean-all-examples.ps1
+++ b/clean-all-examples.ps1
@@ -1,0 +1,49 @@
+# clean-all-examples.ps1
+# Remove all built example binaries and unit output
+
+$exampleBin = "example-bin"
+if (Test-Path $exampleBin) {
+    Write-Host "🧹 Removing example-bin/ directory..." -ForegroundColor Yellow
+    Remove-Item $exampleBin -Recurse -Force
+    Write-Host "✅ example-bin/ cleaned." -ForegroundColor Green
+} else {
+    Write-Host "ℹ️  example-bin/ does not exist. Nothing to clean." -ForegroundColor Gray
+}
+
+$examples = @(
+    'BooleanTest',
+    'ColorDemo',
+    'ErrorHandlingDemo',
+    'LongRunningOpDemo',
+    'MyApp',
+    'MyGit',
+    'ProgressDemo',
+    'SimpleDemo',
+    'SubCommandDemo',
+    'TestFlags'
+)
+
+foreach ($ex in $examples) {
+    $libPath = "examples/$ex/lib"
+    if (Test-Path $libPath) {
+        Write-Host "🧹 Removing old lib/ from examples/$ex..." -ForegroundColor Yellow
+        Remove-Item $libPath -Recurse -Force
+    }
+    $win64Path = "examples/$ex/x86_64-win64"
+    if (Test-Path $win64Path) {
+        Write-Host "🧹 Removing old x86_64-win64/ from examples/$ex..." -ForegroundColor Yellow
+        Remove-Item $win64Path -Recurse -Force
+    }
+    $linuxPath = "examples/$ex/x86_64-linux"
+    if (Test-Path $linuxPath) {
+        Write-Host "🧹 Removing old x86_64-linux/ from examples/$ex..." -ForegroundColor Yellow
+        Remove-Item $linuxPath -Recurse -Force
+    }
+    $backupPath = "examples/$ex/backup"
+    if (Test-Path $backupPath) {
+        Write-Host "🧹 Cleaning backup/ in examples/$ex..." -ForegroundColor Yellow
+        Get-ChildItem $backupPath -Include *.exe,*.dbg,*.o,*.ppu -Recurse | Remove-Item -Force
+    }
+}
+
+Write-Host "`n✅ Cleanup complete." -ForegroundColor Green

--- a/clean-all-examples.sh
+++ b/clean-all-examples.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# clean-all-examples.sh
+# Remove all built example binaries and unit output
+
+set -e
+
+if [ -d "example-bin" ]; then
+  echo "🧹 Removing example-bin/ directory..."
+  rm -rf example-bin
+  echo "✅ example-bin/ cleaned."
+else
+  echo "ℹ️  example-bin/ does not exist. Nothing to clean."
+fi
+
+for ex in BooleanTest ColorDemo ErrorHandlingDemo LongRunningOpDemo MyApp MyGit ProgressDemo SimpleDemo SubCommandDemo TestFlags; do
+  if [ -d "examples/$ex/lib" ]; then
+    echo "🧹 Removing old lib/ from examples/$ex..."
+    rm -rf "examples/$ex/lib"
+  fi
+  if [ -d "examples/$ex/x86_64-win64" ]; then
+    echo "🧹 Removing old x86_64-win64/ from examples/$ex..."
+    rm -rf "examples/$ex/x86_64-win64"
+  fi
+  if [ -d "examples/$ex/x86_64-linux" ]; then
+    echo "🧹 Removing old x86_64-linux/ from examples/$ex..."
+    rm -rf "examples/$ex/x86_64-linux"
+  fi
+  if [ -d "examples/$ex/backup" ]; then
+    echo "🧹 Cleaning backup/ in examples/$ex..."
+    find "examples/$ex/backup" -type f \( -name '*.exe' -o -name '*.dbg' -o -name '*.o' -o -name '*.ppu' \) -delete
+  fi
+done
+
+echo "\n✅ Cleanup complete."

--- a/compile-all-examples.ps1
+++ b/compile-all-examples.ps1
@@ -1,0 +1,43 @@
+# compile-all-examples.ps1
+# Build all example projects in the examples/ folder using lazbuild
+# Usage: ./compile-all-examples.ps1 [lazbuild flags]
+
+param(
+    [Parameter(ValueFromRemainingArguments=$true)]
+    [string[]]$LazbuildArgs
+)
+
+function Check-Lazbuild {
+    if (-not (Get-Command lazbuild -ErrorAction SilentlyContinue)) {
+        Write-Host "❌ Error: lazbuild not found in PATH. Please install Lazarus and ensure lazbuild is available." -ForegroundColor Red
+        exit 1
+    }
+}
+
+$examples = @(
+    'BooleanTest',
+    'ColorDemo',
+    'ErrorHandlingDemo',
+    'LongRunningOpDemo',
+    'MyApp',
+    'MyGit',
+    'ProgressDemo',
+    'SimpleDemo',
+    'SubCommandDemo',
+    'TestFlags'
+)
+
+Check-Lazbuild
+
+foreach ($ex in $examples) {
+    Write-Host "`n🔨 Building $ex ..." -ForegroundColor Cyan
+    lazbuild "examples/$ex/$ex.lpi" @LazbuildArgs
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "❌ Build failed for $ex" -ForegroundColor Red
+        exit 1
+    } else {
+        Write-Host "✅ $ex built successfully." -ForegroundColor Green
+    }
+}
+
+Write-Host "`n🎉 All examples built successfully!" -ForegroundColor Green

--- a/compile-all-examples.sh
+++ b/compile-all-examples.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# compile-all-examples.sh
+# Build all example projects in the examples/ folder using lazbuild
+# Usage: ./compile-all-examples.sh [lazbuild flags]
+
+set -e
+
+if ! command -v lazbuild &> /dev/null; then
+  echo "❌ Error: lazbuild not found in PATH. Please install Lazarus and ensure lazbuild is available." >&2
+  exit 1
+fi
+
+EXAMPLES=(
+  BooleanTest
+  ColorDemo
+  ErrorHandlingDemo
+  LongRunningOpDemo
+  MyApp
+  MyGit
+  ProgressDemo
+  SimpleDemo
+  SubCommandDemo
+  TestFlags
+)
+
+for ex in "${EXAMPLES[@]}"; do
+  echo -e "\n🔨 Building $ex ..."
+  lazbuild "examples/$ex/$ex.lpi" "$@"
+  if [ $? -ne 0 ]; then
+    echo "❌ Build failed for $ex" >&2
+    exit 1
+  else
+    echo "✅ $ex built successfully."
+  fi
+done
+
+echo -e "\n🎉 All examples built successfully!"

--- a/examples/BooleanTest/BooleanTest.lpi
+++ b/examples/BooleanTest/BooleanTest.lpi
@@ -8,7 +8,6 @@
         <MainUnitHasCreateFormStatements Value="False"/>
         <MainUnitHasTitleStatement Value="False"/>
         <MainUnitHasScaledStatement Value="False"/>
-        <UseDefaultCompilerOptions Value="True"/>
       </Flags>
       <SessionStorage Value="InProjectDir"/>
       <Title Value="BooleanTest"/>
@@ -25,6 +24,8 @@
             <Filename Value="BooleanTest"/>
           </Target>
           <SearchPaths>
+            <IncludeFiles Value="$(ProjOutDir)"/>
+            <OtherUnitFiles Value="..\..\src"/>
             <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
           <Parsing>
@@ -48,6 +49,9 @@
               <TrashVariables Value="True"/>
             </Debugging>
           </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
         </CompilerOptions>
       </Item>
       <Item Name="Release">
@@ -76,6 +80,9 @@
             </Debugging>
             <LinkSmart Value="True"/>
           </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
         </CompilerOptions>
       </Item>
     </BuildModes>
@@ -100,8 +107,13 @@
       <Filename Value="BooleanTest"/>
     </Target>
     <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <OtherUnitFiles Value="..\..\src"/>
       <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
+    <Other>
+      <CustomOptions Value="-FcUTF8"/>
+    </Other>
   </CompilerOptions>
   <Debugging>
     <Exceptions>

--- a/examples/BooleanTest/BooleanTest.lpi
+++ b/examples/BooleanTest/BooleanTest.lpi
@@ -15,18 +15,18 @@
       <ResourceType Value="res"/>
     </General>
     <BuildModes>
-      <Item Name="Default" Default="True"/>
-      <Item Name="Debug">
+      <Item Name="Default"/>
+      <Item Name="Debug" Default="True">
         <CompilerOptions>
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="BooleanTest"/>
+            <Filename Value="..\..\example-bin\BooleanTest"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value="..\..\src"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
           <Parsing>
             <SyntaxOptions>
@@ -59,12 +59,12 @@
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="BooleanTest"/>
+            <Filename Value="..\..\example-bin\BooleanTest"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value="..\..\src"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
           <CodeGeneration>
             <SmartLinkUnit Value="True"/>
@@ -104,12 +104,12 @@
     <Version Value="11"/>
     <PathDelim Value="\"/>
     <Target>
-      <Filename Value="BooleanTest"/>
+      <Filename Value="..\..\example-bin\BooleanTest"/>
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>
       <OtherUnitFiles Value="..\..\src"/>
-      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+      <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
     <Other>
       <CustomOptions Value="-FcUTF8"/>

--- a/examples/ColorDemo/ColorDemo.lpi
+++ b/examples/ColorDemo/ColorDemo.lpi
@@ -15,18 +15,36 @@
       <ResourceType Value="res"/>
     </General>
     <BuildModes>
-      <Item Name="Default" Default="True"/>
-      <Item Name="Debug">
+      <Item Name="Default">
         <CompilerOptions>
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="ColorDemo"/>
+            <Filename Value="..\..\example-bin\ColorDemo"/>
           </Target>
           <SearchPaths>
             <OtherUnitFiles Value="..\..\src"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
+        </CompilerOptions>
+      </Item>
+      <Item Name="Debug" Default="True">
+        <CompilerOptions>
+          <Version Value="11"/>
+          <PathDelim Value="\"/>
+          <Target>
+            <Filename Value="..\..\example-bin\ColorDemo"/>
+          </Target>
+          <SearchPaths>
+            <OtherUnitFiles Value="..\..\src"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
+          </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
           <Parsing>
             <SyntaxOptions>
               <IncludeAssertionCode Value="True"/>
@@ -49,9 +67,6 @@
               <UseExternalDbgSyms Value="True"/>
             </Debugging>
           </Linking>
-          <Other>
-            <CustomOptions Value="-FcUTF8"/>
-          </Other>
         </CompilerOptions>
       </Item>
       <Item Name="Release">
@@ -59,13 +74,16 @@
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="ColorDemo"/>
+            <Filename Value="..\..\example-bin\ColorDemo"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value="..\..\src"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
           <CodeGeneration>
             <SmartLinkUnit Value="True"/>
             <Optimizations>
@@ -79,9 +97,6 @@
             </Debugging>
             <LinkSmart Value="True"/>
           </Linking>
-          <Other>
-            <CustomOptions Value="-FcUTF8"/>
-          </Other>
         </CompilerOptions>
       </Item>
     </BuildModes>
@@ -103,11 +118,11 @@
     <Version Value="11"/>
     <PathDelim Value="\"/>
     <Target>
-      <Filename Value="ColorDemo"/>
+      <Filename Value="..\..\example-bin\ColorDemo"/>
     </Target>
     <SearchPaths>
       <OtherUnitFiles Value="..\..\src"/>
-      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+      <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
     <Other>
       <CustomOptions Value="-FcUTF8"/>

--- a/examples/ColorDemo/ColorDemo.lpi
+++ b/examples/ColorDemo/ColorDemo.lpi
@@ -8,7 +8,6 @@
         <MainUnitHasCreateFormStatements Value="False"/>
         <MainUnitHasTitleStatement Value="False"/>
         <MainUnitHasScaledStatement Value="False"/>
-        <UseDefaultCompilerOptions Value="True"/>
       </Flags>
       <SessionStorage Value="InProjectDir"/>
       <Title Value="ColorDemo"/>
@@ -25,6 +24,7 @@
             <Filename Value="ColorDemo"/>
           </Target>
           <SearchPaths>
+            <OtherUnitFiles Value="..\..\src"/>
             <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
           <Parsing>
@@ -49,6 +49,9 @@
               <UseExternalDbgSyms Value="True"/>
             </Debugging>
           </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
         </CompilerOptions>
       </Item>
       <Item Name="Release">
@@ -76,6 +79,9 @@
             </Debugging>
             <LinkSmart Value="True"/>
           </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
         </CompilerOptions>
       </Item>
     </BuildModes>
@@ -100,8 +106,12 @@
       <Filename Value="ColorDemo"/>
     </Target>
     <SearchPaths>
+      <OtherUnitFiles Value="..\..\src"/>
       <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
+    <Other>
+      <CustomOptions Value="-FcUTF8"/>
+    </Other>
   </CompilerOptions>
   <Debugging>
     <Exceptions>

--- a/examples/ErrorHandlingDemo/ErrorHandlingDemo.lpi
+++ b/examples/ErrorHandlingDemo/ErrorHandlingDemo.lpi
@@ -50,6 +50,9 @@
               <UseExternalDbgSyms Value="True"/>
             </Debugging>
           </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
         </CompilerOptions>
       </Item>
       <Item Name="Release">
@@ -77,6 +80,9 @@
             </Debugging>
             <LinkSmart Value="True"/>
           </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
         </CompilerOptions>
       </Item>
     </BuildModes>
@@ -101,8 +107,13 @@
       <Filename Value="ErrorHandlingDemo"/>
     </Target>
     <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <OtherUnitFiles Value="..\..\src"/>
       <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
+    <Other>
+      <CustomOptions Value="-FcUTF8"/>
+    </Other>
   </CompilerOptions>
   <Debugging>
     <Exceptions>

--- a/examples/ErrorHandlingDemo/ErrorHandlingDemo.lpi
+++ b/examples/ErrorHandlingDemo/ErrorHandlingDemo.lpi
@@ -15,19 +15,22 @@
       <ResourceType Value="res"/>
     </General>
     <BuildModes>
-      <Item Name="Default" Default="True"/>
-      <Item Name="Debug">
+      <Item Name="Default"/>
+      <Item Name="Debug" Default="True">
         <CompilerOptions>
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="ErrorHandlingDemo"/>
+            <Filename Value="..\..\example-bin\ErrorHandlingDemo"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value="..\..\src"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
           <Parsing>
             <SyntaxOptions>
               <IncludeAssertionCode Value="True"/>
@@ -50,9 +53,6 @@
               <UseExternalDbgSyms Value="True"/>
             </Debugging>
           </Linking>
-          <Other>
-            <CustomOptions Value="-FcUTF8"/>
-          </Other>
         </CompilerOptions>
       </Item>
       <Item Name="Release">
@@ -60,13 +60,16 @@
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="ErrorHandlingDemo"/>
+            <Filename Value="..\..\example-bin\ErrorHandlingDemo"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value="..\..\src"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
           <CodeGeneration>
             <SmartLinkUnit Value="True"/>
             <Optimizations>
@@ -80,9 +83,6 @@
             </Debugging>
             <LinkSmart Value="True"/>
           </Linking>
-          <Other>
-            <CustomOptions Value="-FcUTF8"/>
-          </Other>
         </CompilerOptions>
       </Item>
     </BuildModes>
@@ -104,12 +104,12 @@
     <Version Value="11"/>
     <PathDelim Value="\"/>
     <Target>
-      <Filename Value="ErrorHandlingDemo"/>
+      <Filename Value="..\..\example-bin\ErrorHandlingDemo"/>
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>
       <OtherUnitFiles Value="..\..\src"/>
-      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+      <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
     <Other>
       <CustomOptions Value="-FcUTF8"/>

--- a/examples/LongRunningOpDemo/LongRunningOpDemo.lpi
+++ b/examples/LongRunningOpDemo/LongRunningOpDemo.lpi
@@ -50,6 +50,9 @@
               <UseExternalDbgSyms Value="True"/>
             </Debugging>
           </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
         </CompilerOptions>
       </Item>
       <Item Name="Release">
@@ -77,6 +80,9 @@
             </Debugging>
             <LinkSmart Value="True"/>
           </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
         </CompilerOptions>
       </Item>
     </BuildModes>
@@ -101,8 +107,13 @@
       <Filename Value="LongRunningOpDemo"/>
     </Target>
     <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <OtherUnitFiles Value="..\..\src"/>
       <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
+    <Other>
+      <CustomOptions Value="-FcUTF8"/>
+    </Other>
   </CompilerOptions>
   <Debugging>
     <Exceptions>

--- a/examples/LongRunningOpDemo/LongRunningOpDemo.lpi
+++ b/examples/LongRunningOpDemo/LongRunningOpDemo.lpi
@@ -15,19 +15,38 @@
       <ResourceType Value="res"/>
     </General>
     <BuildModes>
-      <Item Name="Default" Default="True"/>
-      <Item Name="Debug">
+      <Item Name="Default">
         <CompilerOptions>
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="LongRunningOpDemo"/>
+            <Filename Value="..\..\example-bin\LongRunningOpDemo"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value="..\..\src"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
+        </CompilerOptions>
+      </Item>
+      <Item Name="Debug" Default="True">
+        <CompilerOptions>
+          <Version Value="11"/>
+          <PathDelim Value="\"/>
+          <Target>
+            <Filename Value="..\..\example-bin\LongRunningOpDemo"/>
+          </Target>
+          <SearchPaths>
+            <IncludeFiles Value="$(ProjOutDir)"/>
+            <OtherUnitFiles Value="..\..\src"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
+          </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
           <Parsing>
             <SyntaxOptions>
               <IncludeAssertionCode Value="True"/>
@@ -50,9 +69,6 @@
               <UseExternalDbgSyms Value="True"/>
             </Debugging>
           </Linking>
-          <Other>
-            <CustomOptions Value="-FcUTF8"/>
-          </Other>
         </CompilerOptions>
       </Item>
       <Item Name="Release">
@@ -60,13 +76,16 @@
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="LongRunningOpDemo"/>
+            <Filename Value="..\..\example-bin\LongRunningOpDemo"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value="..\..\src"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
           <CodeGeneration>
             <SmartLinkUnit Value="True"/>
             <Optimizations>
@@ -80,9 +99,6 @@
             </Debugging>
             <LinkSmart Value="True"/>
           </Linking>
-          <Other>
-            <CustomOptions Value="-FcUTF8"/>
-          </Other>
         </CompilerOptions>
       </Item>
     </BuildModes>
@@ -104,12 +120,12 @@
     <Version Value="11"/>
     <PathDelim Value="\"/>
     <Target>
-      <Filename Value="LongRunningOpDemo"/>
+      <Filename Value="..\..\example-bin\LongRunningOpDemo"/>
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>
       <OtherUnitFiles Value="..\..\src"/>
-      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+      <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
     <Other>
       <CustomOptions Value="-FcUTF8"/>

--- a/examples/MyApp/MyApp.lpi
+++ b/examples/MyApp/MyApp.lpi
@@ -15,19 +15,38 @@
       <ResourceType Value="res"/>
     </General>
     <BuildModes>
-      <Item Name="Default" Default="True"/>
-      <Item Name="Debug">
+      <Item Name="Default">
         <CompilerOptions>
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="MyApp"/>
+            <Filename Value="..\..\example-bin\MyApp"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value="..\..\src"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
+        </CompilerOptions>
+      </Item>
+      <Item Name="Debug" Default="True">
+        <CompilerOptions>
+          <Version Value="11"/>
+          <PathDelim Value="\"/>
+          <Target>
+            <Filename Value="..\..\example-bin\MyApp"/>
+          </Target>
+          <SearchPaths>
+            <IncludeFiles Value="$(ProjOutDir)"/>
+            <OtherUnitFiles Value="..\..\src"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
+          </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
           <Parsing>
             <SyntaxOptions>
               <IncludeAssertionCode Value="True"/>
@@ -50,9 +69,6 @@
               <UseExternalDbgSyms Value="True"/>
             </Debugging>
           </Linking>
-          <Other>
-            <CustomOptions Value="-FcUTF8"/>
-          </Other>
         </CompilerOptions>
       </Item>
       <Item Name="Release">
@@ -60,13 +76,16 @@
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="MyApp"/>
+            <Filename Value="..\..\example-bin\MyApp"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value="..\..\src"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
           <CodeGeneration>
             <SmartLinkUnit Value="True"/>
             <Optimizations>
@@ -80,9 +99,6 @@
             </Debugging>
             <LinkSmart Value="True"/>
           </Linking>
-          <Other>
-            <CustomOptions Value="-FcUTF8"/>
-          </Other>
         </CompilerOptions>
       </Item>
     </BuildModes>
@@ -104,12 +120,12 @@
     <Version Value="11"/>
     <PathDelim Value="\"/>
     <Target>
-      <Filename Value="MyApp"/>
+      <Filename Value="..\..\example-bin\MyApp"/>
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>
       <OtherUnitFiles Value="..\..\src"/>
-      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+      <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
     <Other>
       <CustomOptions Value="-FcUTF8"/>

--- a/examples/MyApp/MyApp.lpi
+++ b/examples/MyApp/MyApp.lpi
@@ -50,6 +50,9 @@
               <UseExternalDbgSyms Value="True"/>
             </Debugging>
           </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
         </CompilerOptions>
       </Item>
       <Item Name="Release">
@@ -77,6 +80,9 @@
             </Debugging>
             <LinkSmart Value="True"/>
           </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
         </CompilerOptions>
       </Item>
     </BuildModes>
@@ -101,8 +107,13 @@
       <Filename Value="MyApp"/>
     </Target>
     <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <OtherUnitFiles Value="..\..\src"/>
       <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
+    <Other>
+      <CustomOptions Value="-FcUTF8"/>
+    </Other>
   </CompilerOptions>
   <Debugging>
     <Exceptions>

--- a/examples/MyGit/MyGit.lpi
+++ b/examples/MyGit/MyGit.lpi
@@ -50,6 +50,9 @@
               <UseExternalDbgSyms Value="True"/>
             </Debugging>
           </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
         </CompilerOptions>
       </Item>
       <Item Name="Release">
@@ -77,6 +80,9 @@
             </Debugging>
             <LinkSmart Value="True"/>
           </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
         </CompilerOptions>
       </Item>
     </BuildModes>
@@ -101,8 +107,13 @@
       <Filename Value="MyGit"/>
     </Target>
     <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <OtherUnitFiles Value="..\..\src"/>
       <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
+    <Other>
+      <CustomOptions Value="-FcUTF8"/>
+    </Other>
   </CompilerOptions>
   <Debugging>
     <Exceptions>

--- a/examples/MyGit/MyGit.lpi
+++ b/examples/MyGit/MyGit.lpi
@@ -15,19 +15,38 @@
       <ResourceType Value="res"/>
     </General>
     <BuildModes>
-      <Item Name="Default" Default="True"/>
-      <Item Name="Debug">
+      <Item Name="Default">
         <CompilerOptions>
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="MyGit"/>
+            <Filename Value="..\..\example-bin\MyGit"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value="..\..\src"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
+        </CompilerOptions>
+      </Item>
+      <Item Name="Debug" Default="True">
+        <CompilerOptions>
+          <Version Value="11"/>
+          <PathDelim Value="\"/>
+          <Target>
+            <Filename Value="..\..\example-bin\MyGit"/>
+          </Target>
+          <SearchPaths>
+            <IncludeFiles Value="$(ProjOutDir)"/>
+            <OtherUnitFiles Value="..\..\src"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
+          </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
           <Parsing>
             <SyntaxOptions>
               <IncludeAssertionCode Value="True"/>
@@ -50,9 +69,6 @@
               <UseExternalDbgSyms Value="True"/>
             </Debugging>
           </Linking>
-          <Other>
-            <CustomOptions Value="-FcUTF8"/>
-          </Other>
         </CompilerOptions>
       </Item>
       <Item Name="Release">
@@ -60,13 +76,16 @@
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="MyGit"/>
+            <Filename Value="..\..\example-bin\MyGit"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value="..\..\src"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
           <CodeGeneration>
             <SmartLinkUnit Value="True"/>
             <Optimizations>
@@ -80,9 +99,6 @@
             </Debugging>
             <LinkSmart Value="True"/>
           </Linking>
-          <Other>
-            <CustomOptions Value="-FcUTF8"/>
-          </Other>
         </CompilerOptions>
       </Item>
     </BuildModes>
@@ -104,12 +120,12 @@
     <Version Value="11"/>
     <PathDelim Value="\"/>
     <Target>
-      <Filename Value="MyGit"/>
+      <Filename Value="..\..\example-bin\MyGit"/>
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>
       <OtherUnitFiles Value="..\..\src"/>
-      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+      <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
     <Other>
       <CustomOptions Value="-FcUTF8"/>

--- a/examples/ProgressDemo/ProgressDemo.lpi
+++ b/examples/ProgressDemo/ProgressDemo.lpi
@@ -8,7 +8,6 @@
         <MainUnitHasCreateFormStatements Value="False"/>
         <MainUnitHasTitleStatement Value="False"/>
         <MainUnitHasScaledStatement Value="False"/>
-        <UseDefaultCompilerOptions Value="True"/>
       </Flags>
       <SessionStorage Value="InProjectDir"/>
       <Title Value="ProgressDemo"/>
@@ -51,6 +50,9 @@
               <UseExternalDbgSyms Value="True"/>
             </Debugging>
           </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
         </CompilerOptions>
       </Item>
       <Item Name="Release">
@@ -78,6 +80,9 @@
             </Debugging>
             <LinkSmart Value="True"/>
           </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
         </CompilerOptions>
       </Item>
     </BuildModes>
@@ -102,8 +107,13 @@
       <Filename Value="ProgressDemo"/>
     </Target>
     <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <OtherUnitFiles Value="..\..\src"/>
       <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
+    <Other>
+      <CustomOptions Value="-FcUTF8"/>
+    </Other>
   </CompilerOptions>
   <Debugging>
     <Exceptions>

--- a/examples/ProgressDemo/ProgressDemo.lpi
+++ b/examples/ProgressDemo/ProgressDemo.lpi
@@ -15,19 +15,38 @@
       <ResourceType Value="res"/>
     </General>
     <BuildModes>
-      <Item Name="Default" Default="True"/>
-      <Item Name="Debug">
+      <Item Name="Default">
         <CompilerOptions>
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="ProgressDemo"/>
+            <Filename Value="..\..\example-bin\ProgressDemo"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value="..\..\src"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
+        </CompilerOptions>
+      </Item>
+      <Item Name="Debug" Default="True">
+        <CompilerOptions>
+          <Version Value="11"/>
+          <PathDelim Value="\"/>
+          <Target>
+            <Filename Value="..\..\example-bin\ProgressDemo"/>
+          </Target>
+          <SearchPaths>
+            <IncludeFiles Value="$(ProjOutDir)"/>
+            <OtherUnitFiles Value="..\..\src"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
+          </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
           <Parsing>
             <SyntaxOptions>
               <IncludeAssertionCode Value="True"/>
@@ -50,9 +69,6 @@
               <UseExternalDbgSyms Value="True"/>
             </Debugging>
           </Linking>
-          <Other>
-            <CustomOptions Value="-FcUTF8"/>
-          </Other>
         </CompilerOptions>
       </Item>
       <Item Name="Release">
@@ -60,13 +76,16 @@
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="ProgressDemo"/>
+            <Filename Value="..\..\example-bin\ProgressDemo"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value="..\..\src"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
           <CodeGeneration>
             <SmartLinkUnit Value="True"/>
             <Optimizations>
@@ -80,9 +99,6 @@
             </Debugging>
             <LinkSmart Value="True"/>
           </Linking>
-          <Other>
-            <CustomOptions Value="-FcUTF8"/>
-          </Other>
         </CompilerOptions>
       </Item>
     </BuildModes>
@@ -104,12 +120,12 @@
     <Version Value="11"/>
     <PathDelim Value="\"/>
     <Target>
-      <Filename Value="ProgressDemo"/>
+      <Filename Value="..\..\example-bin\ProgressDemo"/>
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>
       <OtherUnitFiles Value="..\..\src"/>
-      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+      <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
     <Other>
       <CustomOptions Value="-FcUTF8"/>

--- a/examples/SimpleDemo/SimpleDemo.lpi
+++ b/examples/SimpleDemo/SimpleDemo.lpi
@@ -50,6 +50,9 @@
               <UseExternalDbgSyms Value="True"/>
             </Debugging>
           </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
         </CompilerOptions>
       </Item>
       <Item Name="Release">
@@ -77,6 +80,9 @@
             </Debugging>
             <LinkSmart Value="True"/>
           </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
         </CompilerOptions>
       </Item>
     </BuildModes>
@@ -105,6 +111,9 @@
       <OtherUnitFiles Value="..\..\src"/>
       <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
+    <Other>
+      <CustomOptions Value="-FcUTF8"/>
+    </Other>
   </CompilerOptions>
   <Debugging>
     <Exceptions>

--- a/examples/SimpleDemo/SimpleDemo.lpi
+++ b/examples/SimpleDemo/SimpleDemo.lpi
@@ -15,19 +15,38 @@
       <ResourceType Value="res"/>
     </General>
     <BuildModes>
-      <Item Name="Default" Default="True"/>
-      <Item Name="Debug">
+      <Item Name="Default">
         <CompilerOptions>
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="SimpleDemo"/>
+            <Filename Value="..\..\example-bin\SimpleDemo"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value="..\..\src"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
+        </CompilerOptions>
+      </Item>
+      <Item Name="Debug" Default="True">
+        <CompilerOptions>
+          <Version Value="11"/>
+          <PathDelim Value="\"/>
+          <Target>
+            <Filename Value="..\..\example-bin\SimpleDemo"/>
+          </Target>
+          <SearchPaths>
+            <IncludeFiles Value="$(ProjOutDir)"/>
+            <OtherUnitFiles Value="..\..\src"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
+          </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
           <Parsing>
             <SyntaxOptions>
               <IncludeAssertionCode Value="True"/>
@@ -50,9 +69,6 @@
               <UseExternalDbgSyms Value="True"/>
             </Debugging>
           </Linking>
-          <Other>
-            <CustomOptions Value="-FcUTF8"/>
-          </Other>
         </CompilerOptions>
       </Item>
       <Item Name="Release">
@@ -60,13 +76,16 @@
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="SimpleDemo"/>
+            <Filename Value="..\..\example-bin\SimpleDemo"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value="..\..\src"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
           <CodeGeneration>
             <SmartLinkUnit Value="True"/>
             <Optimizations>
@@ -80,9 +99,6 @@
             </Debugging>
             <LinkSmart Value="True"/>
           </Linking>
-          <Other>
-            <CustomOptions Value="-FcUTF8"/>
-          </Other>
         </CompilerOptions>
       </Item>
     </BuildModes>
@@ -104,12 +120,12 @@
     <Version Value="11"/>
     <PathDelim Value="\"/>
     <Target>
-      <Filename Value="SimpleDemo"/>
+      <Filename Value="..\..\example-bin\SimpleDemo"/>
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>
       <OtherUnitFiles Value="..\..\src"/>
-      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+      <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
     <Other>
       <CustomOptions Value="-FcUTF8"/>

--- a/examples/SubCommandDemo/SubCommandDemo.lpi
+++ b/examples/SubCommandDemo/SubCommandDemo.lpi
@@ -8,7 +8,6 @@
         <MainUnitHasCreateFormStatements Value="False"/>
         <MainUnitHasTitleStatement Value="False"/>
         <MainUnitHasScaledStatement Value="False"/>
-        <UseDefaultCompilerOptions Value="True"/>
       </Flags>
       <SessionStorage Value="InProjectDir"/>
       <Title Value="SubCommandDemo"/>
@@ -51,6 +50,9 @@
               <UseExternalDbgSyms Value="True"/>
             </Debugging>
           </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
         </CompilerOptions>
       </Item>
       <Item Name="Release">
@@ -78,6 +80,9 @@
             </Debugging>
             <LinkSmart Value="True"/>
           </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
         </CompilerOptions>
       </Item>
     </BuildModes>
@@ -102,8 +107,13 @@
       <Filename Value="SubCommandDemo"/>
     </Target>
     <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <OtherUnitFiles Value="..\..\src"/>
       <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
+    <Other>
+      <CustomOptions Value="-FcUTF8"/>
+    </Other>
   </CompilerOptions>
   <Debugging>
     <Exceptions>

--- a/examples/SubCommandDemo/SubCommandDemo.lpi
+++ b/examples/SubCommandDemo/SubCommandDemo.lpi
@@ -15,19 +15,38 @@
       <ResourceType Value="res"/>
     </General>
     <BuildModes>
-      <Item Name="Default" Default="True"/>
-      <Item Name="Debug">
+      <Item Name="Default">
         <CompilerOptions>
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="SubCommandDemo"/>
+            <Filename Value="..\..\example-bin\SubCommandDemo"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value="..\..\src"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
+        </CompilerOptions>
+      </Item>
+      <Item Name="Debug" Default="True">
+        <CompilerOptions>
+          <Version Value="11"/>
+          <PathDelim Value="\"/>
+          <Target>
+            <Filename Value="..\..\example-bin\SubCommandDemo"/>
+          </Target>
+          <SearchPaths>
+            <IncludeFiles Value="$(ProjOutDir)"/>
+            <OtherUnitFiles Value="..\..\src"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
+          </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
           <Parsing>
             <SyntaxOptions>
               <IncludeAssertionCode Value="True"/>
@@ -50,9 +69,6 @@
               <UseExternalDbgSyms Value="True"/>
             </Debugging>
           </Linking>
-          <Other>
-            <CustomOptions Value="-FcUTF8"/>
-          </Other>
         </CompilerOptions>
       </Item>
       <Item Name="Release">
@@ -60,13 +76,16 @@
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="SubCommandDemo"/>
+            <Filename Value="..\..\example-bin\SubCommandDemo"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value="..\..\src"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
           <CodeGeneration>
             <SmartLinkUnit Value="True"/>
             <Optimizations>
@@ -80,9 +99,6 @@
             </Debugging>
             <LinkSmart Value="True"/>
           </Linking>
-          <Other>
-            <CustomOptions Value="-FcUTF8"/>
-          </Other>
         </CompilerOptions>
       </Item>
     </BuildModes>
@@ -104,12 +120,12 @@
     <Version Value="11"/>
     <PathDelim Value="\"/>
     <Target>
-      <Filename Value="SubCommandDemo"/>
+      <Filename Value="..\..\example-bin\SubCommandDemo"/>
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>
       <OtherUnitFiles Value="..\..\src"/>
-      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+      <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
     <Other>
       <CustomOptions Value="-FcUTF8"/>

--- a/examples/TestFlags/TestFlags.lpi
+++ b/examples/TestFlags/TestFlags.lpi
@@ -16,18 +16,34 @@
       <ResourceType Value="res"/>
     </General>
     <BuildModes>
-      <Item Name="Default" Default="True"/>
-      <Item Name="Debug">
+      <Item Name="Default">
         <CompilerOptions>
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="TestFlags"/>
+            <Filename Value="..\..\example-bin\TestFlags"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value="..\..\src"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
+          </SearchPaths>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
+        </CompilerOptions>
+      </Item>
+      <Item Name="Debug" Default="True">
+        <CompilerOptions>
+          <Version Value="11"/>
+          <PathDelim Value="\"/>
+          <Target>
+            <Filename Value="..\..\example-bin\TestFlags"/>
+          </Target>
+          <SearchPaths>
+            <IncludeFiles Value="$(ProjOutDir)"/>
+            <OtherUnitFiles Value="..\..\src"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
           <Parsing>
             <SyntaxOptions>
@@ -50,6 +66,9 @@
               <TrashVariables Value="True"/>
             </Debugging>
           </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
         </CompilerOptions>
       </Item>
       <Item Name="Release">
@@ -57,12 +76,12 @@
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="TestFlags"/>
+            <Filename Value="..\..\example-bin\TestFlags"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value="..\..\src"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
           <CodeGeneration>
             <SmartLinkUnit Value="True"/>
@@ -78,6 +97,9 @@
             </Debugging>
             <LinkSmart Value="True"/>
           </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
         </CompilerOptions>
       </Item>
     </BuildModes>
@@ -100,11 +122,14 @@
     <Version Value="11"/>
     <PathDelim Value="\"/>
     <Target>
-      <Filename Value="TestFlags"/>
+      <Filename Value="..\..\example-bin\TestFlags"/>
     </Target>
     <SearchPaths>
-      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+      <UnitOutputDirectory Value="..\..\example-bin\lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
+    <Other>
+      <CustomOptions Value="-FcUTF8"/>
+    </Other>
   </CompilerOptions>
   <Debugging>
     <Exceptions>

--- a/tests/TestRunner.lpi
+++ b/tests/TestRunner.lpi
@@ -50,6 +50,9 @@
               <UseExternalDbgSyms Value="True"/>
             </Debugging>
           </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
         </CompilerOptions>
       </Item>
       <Item Name="Release">
@@ -61,6 +64,7 @@
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
+            <OtherUnitFiles Value="..\src"/>
             <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
           <CodeGeneration>
@@ -111,6 +115,7 @@
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>
+      <OtherUnitFiles Value="..\src"/>
       <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
   </CompilerOptions>


### PR DESCRIPTION
## Description

This PR updates all example project `.lpi` files and the documentation to improve build consistency and developer experience.

### Changes

- **All example `.lpi` files:**
  - All build modes (`Default`, `Debug`, `Release`) now output executables and units to the root example-bin folder for easier access and cleanup.
  - The `Debug` build mode is now set as the default for all examples, making debugging easier by default.
  - Ensured all build modes include `..\..\src` in `OtherUnitFiles` and use `-FcUTF8` in custom options.

- **README.md:**
  - Added a note in the Quick Start section to inform users that all example builds output to the example-bin folder.

### Motivation

- unified all example binaries and units for easier discovery and cleanup.
- Makes the debug configuration the default, which is more developer-friendly.
- Keeps documentation in sync with the actual project structure.

Fixes #10  (issue)

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

1. Test case name/description: NA
2. Steps to test: Compiled each one.
3. Expected results: Succesfull compilation, and binaries in the `example-bin/`folder.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
