### PR TITLE
Preventing compiler warning

### DIFF
--- a/src/cli.application.pas
+++ b/src/cli.application.pas
@@ -994,6 +994,10 @@ begin
           Result := False;
         end;
       end;
+        ptString,   
+    ptPath,     
+    ptArray,    
+    ptPassword: ; // no validation 
   end;
 end;
 

--- a/src/cli.application.pas
+++ b/src/cli.application.pas
@@ -994,7 +994,7 @@ begin
           Result := False;
         end;
       end;
-        ptString,   
+    ptString,   
     ptPath,     
     ptArray,    
     ptPassword: ; // no validation 


### PR DESCRIPTION
## Description

Minor fix - added missing options in the case operator to remove compiler warning