### PR TITLE
docs(v1.3.1): improve newcomer guides and project navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-07-28
+
+### Documentation
+
+- Reworked the README around a five-minute generated CLI, a concise Free
+  Pascal primer, accurate help scopes, and clearer framework capabilities.
+- Added a documentation landing page with learning paths, an examples map,
+  repository orientation, and a distinction between current guides and
+  historical release records.
+- Streamlined the user manual entrance, removed duplicated quick-reference
+  material from the learning path, and clarified root-command, help, and
+  parameter terminology.
+- Expanded the code-generator guide with a cross-platform first build and an
+  explanation of how generated Pascal units fit together.
+- Clarified CI-tested platforms separately from expected but currently
+  untested Unix targets.
+
+### Changed
+
+- Updated the README badge and Lazarus package metadata to `1.3.1`.
+
 ## [1.3.0] - 2026-07-28
 
 ### Added
@@ -332,7 +353,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README with quick start guide
 - System requirements and compatibility information
 
-[Unreleased]: https://github.com/ikelaiah/cli-fp/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/ikelaiah/cli-fp/compare/v1.3.1...HEAD
+[1.3.1]: https://github.com/ikelaiah/cli-fp/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/ikelaiah/cli-fp/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/ikelaiah/cli-fp/compare/v1.1.6...v1.2.0
 [1.0.0]: https://github.com/ikelaiah/cli-fp/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -1,33 +1,147 @@
 # Command-Line Interface Framework for Free Pascal 🚀
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/version-1.3.0-blue.svg)](https://github.com/ikelaiah/cli-fp/releases)
+[![Version](https://img.shields.io/badge/version-1.3.1-blue.svg)](https://github.com/ikelaiah/cli-fp/releases)
 [![Free Pascal](https://img.shields.io/badge/Free%20Pascal-3.2.2-blue.svg)](https://www.freepascal.org/)
 [![Lazarus](https://img.shields.io/badge/Lazarus-4.0-orange.svg)](https://www.lazarus-ide.org/)
 [![GitHub stars](https://img.shields.io/github/stars/ikelaiah/cli-fp?style=social)](https://github.com/ikelaiah/cli-fp/stargazers)
 [![GitHub issues](https://img.shields.io/github/issues/ikelaiah/cli-fp)](https://github.com/ikelaiah/cli-fp/issues)
 
-`cli-fp` is a Free Pascal framework for building terminal applications. It
-provides `git`-style commands, typed parameters, generated help, shell
-completion, progress indicators, and coloured output so your application code
-can focus on what each command actually does.
+Build native command-line tools in Object Pascal.
 
-Free Pascal 3.2.2 or newer is recommended. You can use the project generator
-for a new application, add the framework units to an existing project, or
-install the included Lazarus package.
+`cli-fp` adds command trees, typed option metadata, generated help, Bash and
+PowerShell completion, progress indicators, and coloured output to an ordinary
+Free Pascal program. The core framework uses standard FPC units and produces
+a normal native executable—there is no separate application runtime to deploy.
+
+The repository is also a practical Free Pascal showcase: it contains an
+interface-based framework, a JSON-driven source generator, platform-aware
+console code, shell-completion protocols, and an FPCUnit test suite. CI builds
+and tests the project on Windows and Linux.
 
 ## Start Here
 
-- **Creating a new CLI application?** Start with the
-  [project generator](#-project-generator-fastest-start). It creates the
-  project structure, command units, and a `clifp.json` specification for you.
-- **Adding CLI features to an existing Pascal project?** Follow the
-  [manual quick start](#manual-quick-start).
-- **Using Lazarus?** Compile `packages/lazarus/cli_fp.lpk`, then add it to your
-  project's required packages.
+| If you are... | Start with... |
+| --- | --- |
+| New to Free Pascal | [Install Free Pascal](#install-free-pascal), then read [Free Pascal in two minutes](#free-pascal-in-two-minutes) |
+| New to `cli-fp` | [Build your first generated CLI](#build-your-first-generated-cli) |
+| Adding CLI support to an existing Pascal program | [Manual Quick Start](#manual-quick-start) |
+| Using Lazarus | [Lazarus setup](#lazarus-setup) |
+| Looking for a specific API or design detail | [Documentation map](#documentation-map) |
 
-If this is your first Free Pascal project, install FPC first and confirm that
-`fpc -iV` works in your terminal.
+## Install Free Pascal
+
+`cli-fp` targets Free Pascal 3.2.2. Install FPC from the
+[official download page](https://docs.freepascal.org/download.html), or use an
+installation supplied with Lazarus. Confirm the compiler is available:
+
+```text
+fpc -iV
+```
+
+The command should print `3.2.2`. The
+[official Free Pascal manuals](https://www.freepascal.org/docs.html) include a
+language reference, compiler user guide, RTL reference, and FCL reference.
+
+Some Linux distributions split the compiler and Free Component Library into
+separate packages. On Debian and Ubuntu, the same packages used by this
+project's CI can be installed with:
+
+```bash
+sudo apt-get install fp-compiler fp-units-fcl
+```
+
+The FCL package supplies the JSON units used by `cli-fp-gen`.
+
+## Build Your First Generated CLI
+
+This path creates, compiles, and runs a real application before you need to
+understand the framework internals.
+
+### Linux/macOS with Bash
+
+```bash
+git clone https://github.com/ikelaiah/cli-fp.git
+cd cli-fp
+fpc -Futools/cli-fp-gen/src tools/cli-fp-gen/cli_fp_gen.lpr
+./tools/cli-fp-gen/cli_fp_gen init ./build-temp/myapp --name myapp
+cd build-temp/myapp
+fpc -Fu../../src -Fu./src -Fu./src/generated -Fu./src/commands ./src/Myapp.lpr
+./src/Myapp greet --help
+```
+
+### Windows with PowerShell
+
+```powershell
+git clone https://github.com/ikelaiah/cli-fp.git
+Set-Location .\cli-fp
+fpc "-Futools\cli-fp-gen\src" .\tools\cli-fp-gen\cli_fp_gen.lpr
+.\tools\cli-fp-gen\cli_fp_gen.exe init .\build-temp\myapp --name myapp
+Set-Location .\build-temp\myapp
+fpc "-Fu..\..\src" "-Fu.\src" "-Fu.\src\generated" "-Fu.\src\commands" .\src\Myapp.lpr
+.\src\Myapp.exe greet --help
+```
+
+You now have a native executable with a registered `greet` command, generated
+usage text, a typed `--name` option, and no application runtime dependency.
+
+### Make the Generated Command Yours
+
+Open `src/commands/Myapp_Command_Greet.pas`. Command files are user-owned, so
+the generator will not overwrite your implementation during normal
+regeneration. Replace the generated `Execute` method with:
+
+```pascal
+function TGreetCommand.Execute: Integer;
+var
+  PersonName: string;
+begin
+  if not GetParameterValue('--name', PersonName) then
+    PersonName := 'World';
+
+  WriteLn('Hello, ', PersonName, '!');
+  Result := 0;
+end;
+```
+
+Compile again with the same `fpc` command. On Linux or macOS, run:
+
+```bash
+./src/Myapp greet --name Ada
+```
+
+On Windows, run:
+
+```powershell
+.\src\Myapp.exe greet --name Ada
+```
+
+```text
+Hello, Ada!
+```
+
+That small command already uses class inheritance, a virtual method, generated
+parameter registration, framework parsing and defaults, and native
+compilation.
+
+## Free Pascal in Two Minutes
+
+You only need a few conventions to follow this project:
+
+| Pascal concept | Meaning in this repository |
+| --- | --- |
+| `.lpr` file | The program entry point—the file passed to `fpc` |
+| `.pas` file | Usually a reusable unit containing classes or other declarations |
+| `uses` | Imports units, similar to importing modules in other languages |
+| `-Fu<path>` | Adds a directory to FPC's unit search path |
+| `{$mode objfpc}` | Enables the Object Pascal language mode used by `cli-fp` |
+| `TBaseCommand` descendant | A command class whose `Execute` method performs the work |
+| `Halt(App.Execute)` | Returns the framework's exit code to the operating system |
+
+Free Pascal gives this library strong typing, classes, interfaces, generics,
+exceptions, deterministic `try..finally` cleanup, conditional compilation, and
+native binaries. `cli-fp` packages those capabilities into a focused CLI
+developer experience.
 
 ## Choose Your CLI Shape
 
@@ -40,130 +154,51 @@ application, or combine both:
 | `MyApp --name Gus` | Root action | Root command |
 | `MyApp about` | Named `about` command | `about` command |
 | `MyApp about --verbose` | Named `about` command | `about` command |
-| `MyApp --help` | Framework help | Application-global |
+| `MyApp --help` | General application help, including root options | Application-level |
 
-Root options belong to the default action; they are not automatically inherited
-by named commands. Standalone application requests such as `--help`,
-`--version`, and completion-script generation take precedence over root
-execution.
+Root options belong to the default action; they are not inherited by named
+commands. Built-in requests have distinct scopes:
 
-## 📑 Table of Contents
+- Used alone, `--help`/`-h` shows general application help,
+  `--help-complete` shows the complete command reference, and
+  `--version`/`-v` prints version information.
+- After a named command or subcommand, `--help`/`-h` shows help for that
+  selected level.
+- Completion-script generation is handled at application level when
+  `--completion-file` or `--completion-file-pwsh` is the first argument.
 
-- [Start Here](#start-here)
-- [Choose Your CLI Shape](#choose-your-cli-shape)
-- [✨ Features](#-features)
-- [🧩 Project Generator: Fastest Start](#-project-generator-fastest-start)
-- [Manual Quick Start](#manual-quick-start)
-- [🌱 Root Commands](#-root-commands)
-- [🎯 Parameter Types and Validation](#-parameter-types-and-validation)
-  - [Basic Types](#basic-types)
-  - [Boolean and Flags](#boolean-and-flags)
-  - [Complex Types](#complex-types)
-  - [Validation Rules](#validation-rules)
-- [🧩 Shell Completion](#-shell-completion)
-- [📖 Screenshots](#-screenshots)
-- [📖 System Requirements](#-system-requirements)
-  - [Tested Environments](#tested-environments)
-  - [Theoretical Compatibility](#theoretical-compatibility)
-  - [Dependencies](#dependencies)
-  - [Build Requirements](#build-requirements)
-- [📖 Documentation](#-documentation)
-- [🎯 Use Cases](#-use-cases)
-- [🤝 Contributing](#-contributing)
-- [📝 License](#-license)
-- [🙏 Acknowledgments](#-acknowledgments)
-
-## ✨ Features
+## Feature Tour
 
 - **Commands and subcommands:** Build command trees such as
-  `app repo clone`.
-- **Optional root commands:** Build command-less applications that run as
-  `app [options]` while retaining named commands when needed.
+  `app repo remote add`.
+- **Optional root commands:** Build focused applications that run as
+  `app [options]`, while retaining named commands when useful.
 - **Typed parameter metadata:** Define strings, numbers, paths, URLs, enums,
   passwords, arrays, booleans, and date/time values, with type-specific
-  validation where the framework provides it.
-- **Helpful terminal UX:** Generate contextual help, defaults, required-value
-  errors, and suggestions for unknown commands.
-- **Shell completion:** Generate Bash and PowerShell completion scripts,
-  including boolean and enum value completion.
-- **Console tools:** Use coloured output, spinners, and progress bars with
-  optional status captions.
-- **Project generation:** Scaffold a new application and add or remove command
-  units with `cli-fp-gen`.
-- **Pascal-friendly design:** Use strongly typed interfaces and ordinary FPC
-  units without a separate runtime dependency.
+  validation where implemented.
+- **Generated help:** Show usage, defaults, required options, subcommands, and
+  a complete command reference.
+- **Shell completion:** Generate Bash and PowerShell scripts with contextual
+  command, option, Boolean, and enum suggestions.
+- **Terminal UX:** Use ANSI/Windows colour support, seven spinner styles, and
+  progress bars with inline captions.
+- **Project generation:** Initialize projects and add or remove nested commands
+  from a versioned `clifp.json` specification.
+- **Testable design:** Exercise argument handling without mutating the process
+  command line; the repository includes framework and generator suites.
 
-## 🧩 Project Generator: Fastest Start
+## Contents
 
-For a new application, the generator provides the shortest path to a compiling
-project. Run these commands from the `cli-fp` repository root.
-
-### Linux/macOS (Bash)
-
-```bash
-fpc -Futools/cli-fp-gen/src tools/cli-fp-gen/cli_fp_gen.lpr
-./tools/cli-fp-gen/cli_fp_gen init ./build-temp/myapp --name myapp
-cd build-temp/myapp
-fpc -Fu../../src -Fu./src -Fu./src/generated -Fu./src/commands ./src/Myapp.lpr
-./src/Myapp greet --help
-```
-
-### Windows (PowerShell)
-
-```powershell
-fpc "-Futools\cli-fp-gen\src" .\tools\cli-fp-gen\cli_fp_gen.lpr
-.\tools\cli-fp-gen\cli_fp_gen.exe init .\build-temp\myapp --name myapp
-Set-Location .\build-temp\myapp
-fpc "-Fu..\..\src" "-Fu.\src" "-Fu.\src\generated" "-Fu.\src\commands" .\src\Myapp.lpr
-.\src\Myapp.exe greet --help
-```
-
-The generated project contains a working `greet` command and a `clifp.json`
-specification. Add commands through the generator, or edit the specification
-and regenerate:
-
-```text
-cli-fp-gen add command status --project <project> --description "Show status"
-cli-fp-gen generate --project <project>
-```
-
-To generate a command-less application, add a top-level `rootCommand` object to
-`clifp.json`:
-
-```json
-{
-  "schemaVersion": 1,
-  "app": {
-    "name": "myapp",
-    "version": "0.1.0",
-    "programFile": "src/Myapp.lpr"
-  },
-  "rootCommand": {
-    "description": "Greet someone",
-    "parameters": [
-      {
-        "kind": "string",
-        "short": "-n",
-        "long": "--name",
-        "description": "Name to greet",
-        "required": false,
-        "default": "World",
-        "allowedValues": ""
-      }
-    ]
-  },
-  "commands": []
-}
-```
-
-Running `generate` creates a user-owned `<App>_RootCommand.pas` implementation
-stub and wires it into the generated application. The object deliberately has
-no `name` or `parent`.
-
-See the [generator guide](docs/codegen.md) for the complete schema, generated
-layout, file-ownership rules, and additional commands. Generated Pascal
-filenames use exact casing, such as `src/Myapp.lpr`; preserve that casing on
-Linux and macOS.
+- [Build Your First Generated CLI](#build-your-first-generated-cli)
+- [Free Pascal in Two Minutes](#free-pascal-in-two-minutes)
+- [Choose Your CLI Shape](#choose-your-cli-shape)
+- [Feature Tour](#feature-tour)
+- [Manual Quick Start](#manual-quick-start)
+- [Root Commands](#root-commands)
+- [Parameter Types and Validation](#parameter-types-and-validation)
+- [Shell Completion](#shell-completion)
+- [System Requirements](#system-requirements)
+- [Documentation Map](#documentation-map)
 
 ## Manual Quick Start
 
@@ -273,11 +308,12 @@ Options:
   -h, --help          Show this help message
 ```
 
-**Lazarus users:**
+### Lazarus Setup
+
 A runtime-only Lazarus package is provided in `packages/lazarus/cli_fp.lpk`.
 To use it, open the `.lpk` file in Lazarus, click “Compile,” then click “Add” to add it to your project’s required packages.
 
-## 🌱 Root Commands
+## Root Commands
 
 A root command is the application's unnamed default action. It lets a focused
 utility run with defaults or accept options directly after the executable,
@@ -326,9 +362,11 @@ MyApp about
 See [`RootCommandDemo`](examples/RootCommandDemo/RootCommandDemo.lpr) for a
 complete example.
 
-## 🎯 Parameter Types and Validation
+## Parameter Types and Validation
 
-The framework provides comprehensive type-safe parameter handling with built-in validation:
+The framework records parameter types for validation and help generation.
+Command implementations retrieve the resulting values as strings and convert
+them as needed:
 
 ### Basic Types
 
@@ -393,7 +431,7 @@ Each parameter type has built-in validation:
 - `Array`: No validation on individual items
 - `Password`: No validation or automatic output redaction
 
-## 🧩 Shell Completion
+## Shell Completion
 
 Generate a completion script from your application:
 
@@ -414,54 +452,54 @@ See the [user manual](docs/user-manual.md#bash-completion) for safe installation
 instructions and [`docs/completion-testing/`](docs/completion-testing/) for the
 detailed Bash and PowerShell verification guides.
 
-## 📖 Screenshots
+## Screenshots
 
 ![ColorDemo Help](docs/images/colordemo-help.png)
 ![ColorDemo Greeting](docs/images/colordemo-greeting.png)
 *Above: The ColorDemo example showing professional CLI styling with colors, Unicode characters, and progress indicators.*
 
-## 📖 System Requirements
+## System Requirements
 
 ### Tested Environments
 
-- **Operating System**: Windows 11, Ubuntu 24.04
-- **Compiler**: Free Pascal (FPC) 3.2.2
-- **IDE**: Lazarus 3.6, Lazarus 4.0
+- **Linux CI:** `ubuntu-latest` with the distribution's `fp-compiler` and
+  `fp-units-fcl` packages
+- **Windows CI:** `windows-latest` with Free Pascal 3.2.2 from Lazarus 4.0
 
-### Theoretical Compatibility
+The CI workflow compiles and runs both the framework tests and generator
+tests. Lazarus itself is used to supply the Windows toolchain; the package is
+runtime-only and does not require Lazarus at application runtime.
 
-- **Operating Systems**:
-  - Windows (7, 8, 10, 11)
-  - Linux (Any distribution with FPC support)
-  - macOS (with FPC support)
-  - FreeBSD
-- **Compiler**: Free Pascal 3.2.2 or higher
-- **IDE & Editor**: Any IDE that supports Free Pascal
-  - Lazarus 3.6 or higher
-  - VS Code with Pascal extensions
-  - Other text editors
+### Other Platforms
+
+The console implementation has Windows and Unix code paths, so macOS,
+FreeBSD, and other FPC-supported Unix systems are expected to be viable, but
+they are not currently exercised by this repository's CI. Reports and fixes
+from those platforms are welcome.
 
 ### Dependencies
 
-- No external dependencies required
-- Uses only standard Free Pascal RTL units
+- No third-party libraries are required
+- The framework uses units supplied with Free Pascal
+- The generator additionally uses the standard FCL JSON units
 
 ### Build Requirements
 
-- Free Pascal Compiler (FPC) 3.2.2+
-- Lazarus 3.6+ only when using the Lazarus IDE or package
+- Free Pascal Compiler (the project is tested with FPC 3.2.2)
+- Lazarus only when using the Lazarus IDE or supplied package
 - Git only when cloning the repository rather than using a release archive
 
-## 📖 Documentation
+## Documentation Map
 
-- [User Manual](docs/user-manual.md): Complete guide for using the framework, *including a cheat sheet*
-- [API Reference](docs/api-reference.md): Detailed API reference for the framework
-- [Technical Documentation](docs/technical-docs.md): Architecture and implementation details
-- [Code Generator](docs/codegen.md): `cli-fp-gen` usage, generated layout, and verification notes
-- [Examples](examples/): Working example applications
-- [Changelog](CHANGELOG.md): Version history and updates
+- [Documentation home](docs/README.md): Choose a guide by goal or experience
+- [User manual](docs/user-manual.md): Build applications and use framework features
+- [Code generator](docs/codegen.md): Generate a project and evolve its command tree
+- [API reference](docs/api-reference.md): Look up public types and methods
+- [Technical documentation](docs/technical-docs.md): Understand architecture and internals
+- [Examples](examples/): Explore focused, compilable applications
+- [Changelog](CHANGELOG.md): Review version history and updates
 
-## 🎯 Use Cases
+## Use Cases
 
 Perfect for building:
 
@@ -472,7 +510,7 @@ Perfect for building:
 - System Utilities
 - DevOps Tools
 
-## 🤝 Contributing
+## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.
 
@@ -482,11 +520,11 @@ Contributions are welcome! Please feel free to submit a Pull Request. For major 
 4. Push to the Branch (`git push origin feature/AmazingFeature`)
 5. Open a Pull Request
 
-## 📝 License
+## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
-## 🙏 Acknowledgments
+## Acknowledgments
 
 - Inspired by modern CLI frameworks
 - Built with Free Pascal and Lazarus IDE

--- a/docs/PULL_REQUEST_v1.3.1.md
+++ b/docs/PULL_REQUEST_v1.3.1.md
@@ -1,0 +1,110 @@
+# Pull Request: Release v1.3.1 - Documentation Onboarding and Accuracy
+
+**Target Release:** v1.3.1
+
+**Release Date:** July 28, 2026
+
+## Summary
+
+This PR makes `cli-fp` substantially easier to approach for developers who
+are new to the library or to Free Pascal. It introduces a verified
+first-success path, explains the Object Pascal conventions used by the
+project, improves navigation across the documentation set, and corrects
+platform and API details discovered during the documentation audit.
+
+This is a documentation-focused patch release. It does not change framework
+runtime behaviour, public APIs, generator schemas, or generated output.
+
+## Type of Change
+
+- [x] Documentation improvement
+- [x] Documentation correction
+- [x] Documentation and example verification
+- [ ] New framework feature
+- [ ] Breaking change
+
+## README Onboarding
+
+- [x] Add goal-based “Start Here” routes for new FPC developers, new `cli-fp`
+  users, existing Pascal applications, Lazarus users, and API readers.
+- [x] Add Free Pascal installation and split-package guidance.
+- [x] Add a five-minute generated CLI that reaches a working native
+  executable before introducing framework internals.
+- [x] Show how to replace a generated command implementation and run it.
+- [x] Add a concise Free Pascal and Object Pascal orientation.
+- [x] Explain root, named, and combined CLI application shapes.
+- [x] Present implemented capabilities through a focused feature tour.
+
+## Documentation Navigation
+
+- [x] Add `docs/README.md` as a goal-based documentation landing page.
+- [x] Map examples to the concepts they demonstrate.
+- [x] Add repository-layout orientation for new contributors.
+- [x] Distinguish current guides from release notes and dated test records.
+- [x] Add navigation between the user manual, generator guide, API reference,
+  technical documentation, and completion guides.
+- [x] Mark advanced references with their intended audience.
+
+## Manual and Generator Guides
+
+- [x] Replace the user manual’s duplicated opening cheat sheet with
+  prerequisites and learning paths.
+- [x] Retain one API cheat sheet for quick lookup.
+- [x] Clarify root-command, parameter retrieval, help, debug, and console
+  terminology.
+- [x] Expand the generator guide with verified Bash and PowerShell first-build
+  paths.
+- [x] Explain the roles of `.lpr`, generated units, user-owned command units,
+  `clifp.json`, and FPC unit-search paths.
+
+## Accuracy Corrections
+
+- [x] Distinguish typed parameter metadata and validation from string-based
+  value retrieval.
+- [x] Clarify the FCL JSON dependency used by `cli-fp-gen`.
+- [x] Quote PowerShell `-Fu` arguments where required.
+- [x] Separate CI-tested platforms from expected but currently untested Unix
+  compatibility.
+- [x] Describe Windows console colour handling and ANSI-dependent cursor
+  operations accurately.
+- [x] Expand public API excerpts and document omitted testing and disabled
+  callback surfaces.
+- [x] Preserve the distinct application, command-level, complete-help,
+  version, and completion-script scopes.
+
+## Compatibility
+
+No application or generator migration is required:
+
+- framework source is unchanged;
+- public API signatures are unchanged;
+- `clifp.json` schema version 1 is unchanged;
+- generated project ownership rules are unchanged; and
+- existing applications do not need to be rebuilt for this documentation
+  release.
+
+## Verification
+
+- [x] Framework suite: 38 tests, 0 failures.
+- [x] Full Windows code-generator suite.
+- [x] Documented generator build and generated-application compile.
+- [x] Documented `TGreetCommand.Execute` implementation and
+  `Hello, Ada!` runtime result.
+- [x] General-help and command-help runtime smoke tests.
+- [x] `RootCommandDemo` compile and runtime smoke tests.
+- [x] Lazarus runtime package build with metadata at `1.3.1`.
+- [x] All local targets and heading anchors across 30 Markdown files.
+- [x] Balanced fenced code blocks across 30 Markdown files.
+- [x] `git diff --check`.
+- [ ] GitHub Actions after the PR is opened.
+
+## Release Readiness
+
+- [x] Changelog entry prepared under `Unreleased`.
+- [x] v1.3.1 release notes prepared.
+- [x] Finalize the release date.
+- [x] Update version metadata to `1.3.1` where required.
+- [ ] Confirm GitHub Actions on Linux and Windows.
+- [x] Move the changelog entry from `Unreleased` to a dated `1.3.1` section.
+
+After merge, create the `v1.3.1` tag and publish the prepared release notes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,85 @@
+# cli-fp Documentation
+
+[Project README](../README.md) · [Examples](../examples/) ·
+[Changelog](../CHANGELOG.md)
+
+Use this page to choose the shortest path to the information you need. If this
+is your first Free Pascal command-line project, begin with the
+[five-minute generated CLI](../README.md#build-your-first-generated-cli).
+
+## Choose a Guide
+
+| Goal | Guide |
+| --- | --- |
+| Install FPC and compile a first native CLI | [README: Start Here](../README.md#start-here) |
+| Learn the framework from application setup through advanced features | [User manual](user-manual.md) |
+| Generate a project or change its command tree | [Code generator](codegen.md) |
+| Look up a public type or method | [API reference](api-reference.md) |
+| Understand ownership, parsing, execution, and internal design | [Technical documentation](technical-docs.md) |
+| See small programs that compile | [Examples](../examples/) |
+| Test generated shell completion | [Completion testing guides](completion-testing/) |
+| Review changes between releases | [Changelog](../CHANGELOG.md) |
+
+## New to Free Pascal?
+
+The [Free Pascal in two minutes](../README.md#free-pascal-in-two-minutes)
+section explains the file types, compiler switches, and Object Pascal
+conventions used throughout the project. The
+[official Free Pascal manuals](https://www.freepascal.org/docs.html) are the
+authoritative references for the language, compiler, runtime library, and Free
+Component Library.
+
+You do not need Lazarus to use `cli-fp`: an FPC installation with the standard
+FCL units is enough. Lazarus users can instead install the supplied
+[runtime package](../README.md#lazarus-setup).
+
+## Examples by Goal
+
+| Learn about... | Example |
+| --- | --- |
+| A default action plus a named command | [`RootCommandDemo`](../examples/RootCommandDemo/) |
+| Basic commands, options, and output | [`SimpleDemo`](../examples/SimpleDemo/) |
+| Nested command trees | [`SubCommandDemo`](../examples/SubCommandDemo/) |
+| Colours and terminal presentation | [`ColorDemo`](../examples/ColorDemo/) |
+| Spinners and progress bars | [`ProgressDemo`](../examples/ProgressDemo/) |
+| Longer operations and cleanup | [`LongRunningOpDemo`](../examples/LongRunningOpDemo/) |
+| Errors and exit behaviour | [`ErrorHandlingDemo`](../examples/ErrorHandlingDemo/) |
+
+Each example is a normal `.lpr` program. From the repository root, compile one
+on Linux or macOS with:
+
+```bash
+fpc -Fu./src ./examples/RootCommandDemo/RootCommandDemo.lpr
+```
+
+In PowerShell, quote the `-Fu` argument so it reaches FPC as one argument:
+
+```powershell
+fpc "-Fu.\src" .\examples\RootCommandDemo\RootCommandDemo.lpr
+```
+
+## Repository Map
+
+| Path | Purpose |
+| --- | --- |
+| [`src/`](../src/) | Framework units used by applications |
+| [`tools/cli-fp-gen/`](../tools/cli-fp-gen/) | JSON-driven project generator |
+| [`examples/`](../examples/) | Focused runnable applications |
+| [`tests/`](../tests/) | FPCUnit framework tests and generator integration tests |
+| [`packages/lazarus/`](../packages/lazarus/) | Runtime-only Lazarus package |
+| [`docs/`](./) | Guides, references, and release records |
+
+## Current Guides and Historical Records
+
+The README, user manual, code-generator guide, API reference, and technical
+documentation describe the current source tree.
+
+Files named `PULL_REQUEST_v*.md` and `RELEASE_NOTES_v*.md` are snapshots of a
+particular release. `test-output.md` records the test environment and results
+at the time stated in that file. Treat those files as release history rather
+than as the primary usage documentation.
+
+## Found a Documentation Problem?
+
+Please open an issue with the page, section, command, and platform involved.
+Small corrections are welcome as pull requests.

--- a/docs/RELEASE_NOTES_v1.3.1.md
+++ b/docs/RELEASE_NOTES_v1.3.1.md
@@ -1,0 +1,110 @@
+# Release Notes - cli-fp v1.3.1
+
+**Release Date:** July 28, 2026
+
+## Overview
+
+Version `1.3.1` is a documentation-focused patch release that makes `cli-fp`
+easier to learn, evaluate, and adopt. It adds a verified path from installing
+Free Pascal to running a generated native CLI, gives newcomers a concise
+Object Pascal orientation, and reorganizes the documentation around developer
+goals.
+
+The release also corrects dependency, compiler-command, platform-support,
+console, and API descriptions found during a source-backed documentation
+audit.
+
+There are no framework runtime, public API, generator-schema, or generated
+output changes in this release.
+
+## A Faster First Success
+
+The README now guides a new developer through:
+
+1. installing and verifying Free Pascal;
+2. compiling `cli-fp-gen`;
+3. generating an application;
+4. compiling the generated Pascal units into a native executable;
+5. implementing the generated `greet` command; and
+6. running the result as `Myapp greet --name Ada`.
+
+The documented command implementation and its `Hello, Ada!` result were
+compile- and runtime-verified with FPC 3.2.2.
+
+## Free Pascal Orientation
+
+New sections explain the project’s essential Pascal conventions, including:
+
+- `.lpr` program entry points and `.pas` units;
+- `uses` clauses and FPC `-Fu` unit-search paths;
+- `{$mode objfpc}`;
+- `TBaseCommand` inheritance and overridden `Execute` methods; and
+- returning application exit codes through `Halt(App.Execute)`.
+
+The README also highlights how the project uses classes, interfaces, generics,
+exceptions, deterministic cleanup, conditional compilation, FPCUnit, native
+binaries, and platform-aware console code.
+
+## Documentation Navigation
+
+A new `docs/README.md` documentation home provides:
+
+- goal-based routes into the user, generator, API, and maintainer guides;
+- an examples map showing which application demonstrates each feature;
+- a repository-layout overview;
+- guidance for developers new to Free Pascal; and
+- a clear distinction between current documentation and historical release or
+  test records.
+
+The user manual, generator guide, API reference, technical documentation, and
+completion guides now link back into this navigation structure.
+
+## Manual and Generator Improvements
+
+- Replaced the user manual’s duplicated opening reference material with
+  prerequisites and focused learning paths.
+- Retained a single API cheat sheet for experienced users.
+- Clarified root-command selection, help scopes, parameter conversion, debug
+  access, and console behaviour.
+- Added verified cross-platform generator and generated-application commands.
+- Explained how `clifp.json`, the `.lpr` entry point, generated registry units,
+  and user-owned command units become one native executable.
+- Removed the dated “Phase 1” framing from the current generator guide.
+
+## Accuracy Corrections
+
+- Described parameter types as metadata used for validation and help while
+  making clear that command code retrieves values as strings.
+- Documented the standard FCL JSON units required by `cli-fp-gen`.
+- Added required PowerShell quoting around FPC `-Fu` arguments.
+- Separated CI-tested Windows/Linux environments from expected but currently
+  untested Unix targets.
+- Corrected Windows console and ANSI cursor-control descriptions.
+- Expanded selected public API declarations and identified intentionally
+  omitted testing and disabled callback surfaces.
+- Preserved the distinction between general help, command-level help,
+  complete help, version output, and completion-script generation.
+
+## Verification
+
+- Framework suite: 38 tests, 0 failures.
+- Full Windows generator suite passed.
+- The documented generated project compiled and ran successfully.
+- `RootCommandDemo` compiled and completed its root and named actions.
+- The Lazarus runtime package compiled with version metadata at `1.3.1`.
+- Local links and heading anchors across 30 Markdown files resolve.
+- Fenced code blocks across 30 Markdown files are balanced.
+- `git diff --check` passed.
+
+## Compatibility
+
+No migration is required. Existing applications, public API usage,
+schema-version-1 `clifp.json` files, and generated projects continue to work as
+they did in v1.3.0.
+
+## Versioning
+
+- The README release badge now targets `1.3.1`.
+- The Lazarus package metadata now targets `1.3.1`.
+
+**Full Changelog:** [v1.3.0...v1.3.1](https://github.com/ikelaiah/cli-fp/compare/v1.3.0...v1.3.1)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,5 +1,19 @@
 # CLI Framework API Reference
 
+[Documentation home](README.md) · [Project README](../README.md) ·
+[User manual](user-manual.md) · [Technical documentation](technical-docs.md)
+
+Use this page when you already know the framework concept and need its public
+types or method signatures. If you are building your first application, begin
+with the [user manual](user-manual.md); it supplies complete program context
+that the isolated declarations here intentionally omit.
+
+The excerpts focus on supported application-facing members. Test hooks on
+`TCLIApplication` and the currently disabled custom-completion callback
+registry are documented in the
+[technical completion notes](technical-docs.md#historical-investigation-disabled-custom-callbacks).
+The declarations in [`src/`](../src/) remain authoritative.
+
 ## Table of Contents
 
 - [Overview](#overview)
@@ -126,7 +140,7 @@ values and values with or without seconds may also be accepted. Treat
 `YYYY-MM-DD HH:MM` as the recommended portable input until validation is made
 strict.
 
-`AddPasswordParameter` marks a parameter as sensitive, but retrieved values are
+`AddPasswordParameter` records `ptPassword` metadata, but retrieved values are
 ordinary strings. The framework does not automatically redact values written
 by application code or external logging.
 
@@ -272,6 +286,12 @@ Main application class implementing `ICLIApplication`.
 ```pascal
 TCLIApplication = class(TInterfacedObject, ICLIApplication)
 public
+  constructor Create(const AName, AVersion: string;
+    const ARootCommand: ICommand = nil);
+  destructor Destroy; override;
+  procedure RegisterCommand(const Command: ICommand);
+  function Execute: Integer;
+
   property DebugMode: Boolean read FDebugMode write FDebugMode;
   property Version: string read FVersion;
   property RootCommand: ICommand read FRootCommand;
@@ -323,9 +343,17 @@ Base command implementation.
 Abstract base class for all CLI commands.
 ```pascal
 TBaseCommand = class(TInterfacedObject, ICommand)
+protected
+  function GetParameterValue(const Flag: string; out Value: string): Boolean;
+  procedure ShowHelp;
 public
   constructor Create(const AName, ADescription: string);
+  destructor Destroy; override;
+  procedure UpdateDescription(const ADescription: string);
   procedure AddParameter(const Parameter: ICommandParameter);
+  procedure AddParameter(const ShortFlag, LongFlag, Description: string;
+    Required: Boolean; ParamType: TParameterType;
+    const DefaultValue: string = ''; const AllowedValues: string = '');
   procedure AddSubCommand(const Command: ICommand);
   procedure SetParsedParams(const Params: TStringList);
   function Execute: Integer; virtual; abstract;
@@ -336,6 +364,9 @@ public
   property SubCommands: specialize TArray<ICommand> read GetSubCommands;
 end;
 ```
+
+The type-specific `Add*Parameter` methods are listed in
+[Parameter Helper Methods](#parameter-helper-methods).
 
 ### CLI.Parameter
 
@@ -494,6 +525,11 @@ public
   constructor CreateFmt(const Msg: string; const Args: array of const);
 end;
 ```
+
+Specialized descendants are `ECommandNotFoundException`,
+`EInvalidParameterException`, `ERequiredParameterMissingException`,
+`EInvalidParameterValueException`, and `ECommandExecutionException`. Each
+supports the same `Create` and `CreateFmt` constructors.
 
 ## Examples
 

--- a/docs/codegen.md
+++ b/docs/codegen.md
@@ -1,12 +1,76 @@
-# CLI Code Generator (Phase 1)
+# CLI Project Generator
 
-`cli-fp-gen` is a standalone scaffold generator for `cli-fp` applications.
+[Documentation home](README.md) · [Project README](../README.md) ·
+[User manual](user-manual.md) · [API reference](api-reference.md)
 
-Phase 1 focuses on CLI project generation only (no Lazarus wizard yet).
+`cli-fp-gen` turns a small JSON command specification into a native Free
+Pascal project. It creates the program entry point, command registry, and
+user-owned command classes, while keeping generated and hand-written code
+separate.
+
+Use the generator when you want a working project layout immediately or expect
+the command tree to evolve. For a single-file integration into an existing
+program, the [manual quick start](../README.md#manual-quick-start) may be
+simpler.
+
+## Quick Start
+
+Run these commands from the `cli-fp` repository root.
+
+### Linux/macOS with Bash
+
+```bash
+fpc -Futools/cli-fp-gen/src tools/cli-fp-gen/cli_fp_gen.lpr
+./tools/cli-fp-gen/cli_fp_gen init ./build-temp/myapp --name myapp
+cd build-temp/myapp
+fpc -Fu../../src -Fu./src -Fu./src/generated -Fu./src/commands ./src/Myapp.lpr
+./src/Myapp greet --help
+```
+
+### Windows with PowerShell
+
+```powershell
+fpc "-Futools\cli-fp-gen\src" .\tools\cli-fp-gen\cli_fp_gen.lpr
+.\tools\cli-fp-gen\cli_fp_gen.exe init .\build-temp\myapp --name myapp
+Set-Location .\build-temp\myapp
+fpc "-Fu..\..\src" "-Fu.\src" "-Fu.\src\generated" "-Fu.\src\commands" .\src\Myapp.lpr
+.\src\Myapp.exe greet --help
+```
+
+You have now compiled both the generator and a generated application with FPC.
+Next, edit `src/commands/Myapp_Command_Greet.pas` and implement its `Execute`
+method. Change command metadata in `clifp.json`, then regenerate:
+
+```text
+cli-fp-gen generate --project .
+```
+
+Use the platform-specific generator path shown above if it is not installed on
+your command path.
+
+## How Generation Fits Free Pascal
+
+The generated project uses ordinary Object Pascal source files:
+
+| File | Role |
+| --- | --- |
+| `src/Myapp.lpr` | Program entry point passed to `fpc` |
+| `src/generated/*.pas` | Generated units that register the command tree and its parameters |
+| `src/commands/*.pas` | User-owned command classes where `Execute` does the work |
+| `clifp.json` | Language-neutral source of truth for command metadata |
+
+FPC compiles all of these units into one native executable. The four `-Fu`
+arguments in the build command expose, respectively, the `cli-fp` framework,
+the program units, generated units, and command implementations to the
+compiler.
+
+Generation currently targets command-line projects. It does not install a
+Lazarus design-time wizard; Lazarus users may open the generated `.lpr` as a
+project and use the runtime package separately.
 
 ## Location
 
-- Tool source: `tools/cli-fp-gen/`
+- Tool source: [`tools/cli-fp-gen/`](../tools/cli-fp-gen/)
 
 ## Commands
 
@@ -110,7 +174,7 @@ Supported `kind` values:
 - `src/generated/.clifp-manifest.json`: generator-owned manifest for cleanup
 - `src/commands/*.pas`: user-owned command and optional root-command stubs,
   created once and not overwritten unless `--force`
-- `src/*.lpr`: generator-owned in Phase 1
+- `src/*.lpr`: generator-owned by the current generator
 
 ### Cleanup Safety
 

--- a/docs/completion-testing/BASH_COMPLETION_GUIDE.md
+++ b/docs/completion-testing/BASH_COMPLETION_GUIDE.md
@@ -1,7 +1,10 @@
 # Bash Completion User Guide
 
+[Documentation home](../README.md) · [Completion index](README.md) ·
+[PowerShell guide](PS_COMPLETION_GUIDE.md)
+
 **Document Version:** 1.1
-**Last Updated:** 2026-07-27
+**Last Updated:** 2026-07-28
 **Framework:** cli-fp
 **Applies To:** Bash 4.0+ (Linux, macOS with a newer Bash, Git Bash on Windows)
 

--- a/docs/completion-testing/PS_COMPLETION_GUIDE.md
+++ b/docs/completion-testing/PS_COMPLETION_GUIDE.md
@@ -1,7 +1,10 @@
 # PowerShell Completion User Guide
 
+[Documentation home](../README.md) · [Completion index](README.md) ·
+[Bash guide](BASH_COMPLETION_GUIDE.md)
+
 **Document Version:** 1.1
-**Last Updated:** 2026-07-27
+**Last Updated:** 2026-07-28
 **Framework:** cli-fp
 **Applies To:** Windows PowerShell 5.1 on Windows; PowerShell 7+ cross-platform
 

--- a/docs/completion-testing/README.md
+++ b/docs/completion-testing/README.md
@@ -1,7 +1,11 @@
 # Shell Completion Testing Documentation
 
+[Documentation home](../README.md) · [User manual](../user-manual.md) ·
+[Bash guide](BASH_COMPLETION_GUIDE.md) ·
+[PowerShell guide](PS_COMPLETION_GUIDE.md)
+
 **Created:** 2025-12-29
-**Last Updated:** 2026-07-27
+**Last Updated:** 2026-07-28
 **Framework:** cli-fp
 **Coverage:** Bash and PowerShell completion documentation
 

--- a/docs/technical-docs.md
+++ b/docs/technical-docs.md
@@ -1,5 +1,13 @@
 # CLI Framework Technical Documentation
 
+[Documentation home](README.md) · [Project README](../README.md) ·
+[User manual](user-manual.md) · [API reference](api-reference.md)
+
+This is a maintainer-level guide to parser flow, object ownership, help and
+completion generation, console behaviour, and tests. Application authors
+looking for public usage examples should start with the
+[user manual](user-manual.md).
+
 ## Architecture Overview
 
 The Free Pascal CLI Framework is built on a modular, interface-based architecture that promotes extensibility and maintainability. The framework is organized into several key components that work together to provide a complete CLI solution.
@@ -384,19 +392,26 @@ registration currently raises a generic `Exception`.
 ## Platform-Specific Considerations
 
 ### Windows Console Support
+
+Foreground/background colours and colour reset use the Windows console API:
+
 ```pascal
 {$IFDEF WINDOWS}
-  // Uses Windows API for console manipulation
   Handle := GetStdHandle(STD_OUTPUT_HANDLE);
   GetConsoleScreenBufferInfo(Handle, Info);
   SetConsoleTextAttribute(Handle, Attributes);
 {$ENDIF}
 ```
 
-### Unix/Linux Console Support
+Cursor movement and position helpers still emit ANSI control sequences, so
+those operations depend on ANSI-compatible terminal behaviour.
+
+### Unix-Like Console Support
+
+On non-Windows targets, colours and cursor control use ANSI escape sequences:
+
 ```pascal
 {$ELSE}
-  // Uses ANSI escape sequences
   System.Write(#27'[<color_code>m');
 {$ENDIF}
 ```

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -1,213 +1,66 @@
 # CLI Framework User Manual
 
+[Documentation home](README.md) · [Project README](../README.md) ·
+[Code generator](codegen.md) · [API reference](api-reference.md)
+
 ## Overview
 
-The Free Pascal CLI Framework is a modern, feature-rich library for building command-line applications. It provides an intuitive way to create CLIs with commands, subcommands, parameters, and interactive progress indicators.
+`cli-fp` is an Object Pascal library for native command-line applications. It
+provides root commands, named commands and subcommands, typed parameter
+metadata, generated help, shell completion, coloured output, and progress
+indicators.
 
-## Quick Reference Cheat Sheet
+This guide starts with complete programs and then explains individual
+features. For the shortest first success, generate and compile the
+[README tutorial project](../README.md#build-your-first-generated-cli) before
+returning here.
 
-Essential commands for building CLI applications:
+## Before You Begin
 
-### Create Application
-```pascal
-// Create new CLI application
-App := CreateCLIApplication('AppName', '1.0.0');
+The project is tested with Free Pascal 3.2.2. Confirm that the compiler is on
+your command path:
+
+```text
+fpc -iV
 ```
 
-### Create Command
-```pascal
-// TMyCommand must descend from TBaseCommand and override Execute
-Cmd := TMyCommand.Create('command-name', 'Command description');
-```
+When a command in this guide contains `-Fu../cli-fp/src`, adjust the path so it
+points to this repository's `src` directory. `-Fu` adds a unit-search path;
+units named in a Pascal `uses` clause are found there.
 
-### Add Parameters
-```pascal
-// String parameter
-Cmd.AddStringParameter('-n', '--name', 'Description', False, 'default');
+If `.lpr`, `.pas`, `uses`, or `{$mode objfpc}` are new to you, read
+[Free Pascal in two minutes](../README.md#free-pascal-in-two-minutes).
 
-// Integer parameter
-Cmd.AddIntegerParameter('-c', '--count', 'Description', True);  // Required
+## Choose a Learning Path
 
-// Float parameter
-Cmd.AddFloatParameter('-r', '--rate', 'Description', False, '1.0');
-
-// Boolean flag (presence means true)
-Cmd.AddFlag('-v', '--verbose', 'Description');
-
-// Boolean parameter (explicit true/false)
-Cmd.AddBooleanParameter('-d', '--debug', 'Description', False, 'false');
-
-// Path parameter
-Cmd.AddPathParameter('-p', '--path', 'Description', False, GetCurrentDir);
-
-// Enum parameter
-Cmd.AddEnumParameter('-l', '--level', 'Description', 'debug|info|warn|error');
-
-// DateTime parameter (recommended format: YYYY-MM-DD HH:MM)
-Cmd.AddDateTimeParameter('-d', '--date', 'Description');
-
-// Array parameter (comma-separated values)
-Cmd.AddArrayParameter('-t', '--tags', 'Description', False, 'tag1,tag2');
-
-// Password parameter (treat the retrieved string as sensitive)
-Cmd.AddPasswordParameter('-k', '--key', 'Description', True);
-
-// URL parameter (validates URL format)
-Cmd.AddUrlParameter('-u', '--url', 'Description', True);
-```
-
-### Get Parameter Values
-```pascal
-var
-  StrValue, IntValueStr, FloatValueStr, BoolValueStr: string;
-  IntValue: Integer;
-  FloatValue: Double;
-  BoolValue: Boolean;
-begin
-  // For non-boolean parameters, returns True when a value or default exists
-  if GetParameterValue('--param-name', StrValue) then
-    // Use StrValue...
-
-  // Retrieve text, then convert explicitly
-  if GetParameterValue('--count', IntValueStr) then
-    TryStrToInt(IntValueStr, IntValue);
-
-  if GetParameterValue('--rate', FloatValueStr) then
-    TryStrToFloat(FloatValueStr, FloatValue);
-
-  GetParameterValue('--verbose', BoolValueStr);
-  BoolValue := SameText(BoolValueStr, 'true');
-end;
-```
-
-### Add Subcommands
-```pascal
-// Both classes descend from TBaseCommand and override Execute
-MainCmd := TGitCommand.Create('git', 'Git operations');
-
-// Create and add subcommand
-SubCmd := TCloneCommand.Create('clone', 'Clone repository');
-MainCmd.AddSubCommand(SubCmd);
-```
-
-### Register and Run
-```pascal
-// Register command
-App.RegisterCommand(Cmd);
-
-// Run application
-Halt(App.Execute);
-```
-
-### Progress Indicators
-```pascal
-// Spinner (for unknown duration)
-Spinner := CreateSpinner(ssDots);
-Spinner.Start;
-try
-  Spinner.Update(0, 'Working...');
-  // Work here, calling Update regularly...
-finally
-  Spinner.Stop;
-end;
-
-// Progress bar (for known steps)
-Progress := CreateProgressBar(TotalSteps);
-Progress.Start;
-try
-  for i := 1 to TotalSteps do
-  begin
-    // Work here...
-    Progress.Update(i);
-  end;
-finally
-  Progress.Stop;
-end;
-```
+| Goal | Start here |
+| --- | --- |
+| Build a conventional CLI with named commands | [Simple application](#1-creating-a-simple-cli-application) |
+| Build a focused tool invoked as `app [options]` | [Root-command application](#2-creating-a-root-command-application) |
+| Build `git`-style nested commands | [Git-like CLI](#3-creating-a-git-like-cli) |
+| Add spinners or progress bars | [Progress indicators](#4-progress-indicators) |
+| Look up registration calls quickly | [API cheat sheet](#api-cheat-sheet) |
+| Generate the project structure | [Code-generator guide](codegen.md) |
 
 ## Table of Contents
 
-- [CLI Framework User Manual](#cli-framework-user-manual)
-  - [Overview](#overview)
-  - [Quick Reference Cheat Sheet](#quick-reference-cheat-sheet)
-    - [Create Application](#create-application)
-    - [Create Command](#create-command)
-    - [Add Parameters](#add-parameters)
-    - [Get Parameter Values](#get-parameter-values)
-    - [Add Subcommands](#add-subcommands)
-    - [Register and Run](#register-and-run)
-    - [Progress Indicators](#progress-indicators)
-  - [Table of Contents](#table-of-contents)
-  - [Features](#features)
-  - [Application Flow](#application-flow)
-  - [Command Parameter Building Flow](#command-parameter-building-flow)
-  - [Installation](#installation)
-  - [Quick Start](#quick-start)
-    - [1. Creating a Simple CLI Application](#1-creating-a-simple-cli-application)
-    - [2. Creating a Command-less Application](#2-creating-a-command-less-application)
-    - [3. Creating a Git-like CLI](#3-creating-a-git-like-cli)
-    - [4. Progress Indicators](#4-progress-indicators)
-      - [Spinner Types](#spinner-types)
-      - [Using Spinners](#using-spinners)
-      - [Progress Bars](#progress-bars)
-      - [Choosing Between Spinner and Progress Bar](#choosing-between-spinner-and-progress-bar)
-  - [Parameter Types and Validation](#parameter-types-and-validation)
-    - [Basic Types](#basic-types)
-      - [String Parameters](#string-parameters)
-      - [Integer Parameters](#integer-parameters)
-      - [Float Parameters](#float-parameters)
-      - [Boolean Parameters and Flags](#boolean-parameters-and-flags)
-      - [Date and Time Parameters](#date-and-time-parameters)
-      - [Enumerated Values](#enumerated-values)
-      - [URL Parameters](#url-parameters)
-      - [Array Parameters](#array-parameters)
-      - [Password Parameters](#password-parameters)
-    - [Parameter Validation](#parameter-validation)
-    - [Basic Types](#basic-types-1)
-    - [Complex Types](#complex-types)
-    - [Error Messages](#error-messages)
-    - [Required Parameters](#required-parameters)
-    - [Default Values](#default-values)
-    - [Getting Parameter Values](#getting-parameter-values)
-    - [Best Practices](#best-practices)
-  - [Command-Line Usage](#command-line-usage)
-    - [Basic Command Structure](#basic-command-structure)
-    - [Getting Help](#getting-help)
-    - [Parameter Formats](#parameter-formats)
-  - [Troubleshooting](#troubleshooting)
-    - [Common Issues](#common-issues)
-  - [Best Practices](#best-practices-1)
-  - [Useful Unicode Characters for CLI Interfaces](#useful-unicode-characters-for-cli-interfaces)
-  - [Getting Help](#getting-help-1)
-  - [Summary](#summary)
-  - [Cheat Sheet](#cheat-sheet)
-    - [Create Application](#create-application-1)
-    - [Create Command](#create-command-1)
-    - [Add Parameters](#add-parameters-1)
-    - [Get Parameter Values](#get-parameter-values-1)
-    - [Add Subcommands](#add-subcommands-1)
-    - [Register and Run](#register-and-run-1)
-    - [Progress Indicators](#progress-indicators-1)
-  - [Bash Completion](#bash-completion)
-    - [Features of the Generated Script](#features-of-the-generated-script)
-    - [How It Works](#how-it-works)
-      - [Technical Rationale](#technical-rationale)
-  - [PowerShell Tab Completion](#powershell-tab-completion)
-    - [Overview](#overview-1)
-    - [How to Enable](#how-to-enable)
-    - [Usage](#usage)
-    - [Example](#example)
-    - [Notes](#notes)
-
-
-
-
-
+- [Features](#features)
+- [How an application executes](#application-flow)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Parameter types and validation](#parameter-types-and-validation)
+- [Command-line usage](#command-line-usage)
+- [Troubleshooting](#troubleshooting)
+- [Best practices](#best-practices)
+- [API cheat sheet](#api-cheat-sheet)
+- [Bash completion](#bash-completion)
+- [PowerShell tab completion](#powershell-tab-completion)
+- [Where to go next](#where-to-go-next)
 
 ## Features
 
 - Command and subcommand support
-- Optional root commands for command-less applications
+- Optional root commands for applications with a default action
 - Parameter handling with validation
 - Progress indicators (spinner and progress bar)
 - Colored console output
@@ -355,7 +208,7 @@ begin
 end.
 ```
 
-### 2. Creating a Command-less Application
+### 2. Creating a Root-Command Application
 
 An optional root command runs as the executable's default action. It uses the
 same `TBaseCommand` parameter and validation APIs as named commands, but its
@@ -697,7 +550,7 @@ Use a **Progress Bar** when:
 
 The framework provides a rich set of parameter types with built-in validation:
 
-### Basic Types
+### Registration Methods by Type
 
 #### String Parameters
 ```pascal
@@ -768,7 +621,7 @@ external logging.
 
 The framework validates all parameters before executing a command. Each parameter type has specific validation rules:
 
-### Basic Types
+### Validation Rules by Type
 - **String**: No validation
 - **Integer**: Must be a valid integer number
 - **Float**: Must be a valid floating-point number
@@ -862,7 +715,7 @@ begin
 end;
 ```
 
-### Best Practices
+### Parameter Best Practices
 
 1. **Check the Retrieved Boolean Text**: `GetParameterValue` returns `True`
    when a value or non-empty default exists. Standard flags have the default
@@ -910,9 +763,11 @@ myapp [root-options]          # when a root command is configured
 
 ### Getting Help
 
-- Show general help: `myapp -h` or `myapp --help`
-- Show detailed reference: `myapp --help-complete`
-- Show command help: `myapp <command> --help`
+- Used alone, `myapp -h` or `myapp --help` shows general application help.
+- `myapp --help-complete` shows the complete command reference.
+- `myapp <command> --help` shows help for the selected command level.
+- Used alone, `myapp -v` or `myapp --version` prints application version
+  information.
 
 ### Parameter Formats
 
@@ -934,10 +789,15 @@ myapp test               # --flag is false
 1. **Command Not Found**
    - Verify command name spelling
    - Check if command is properly registered with `App.RegisterCommand`
-   - Enable debug mode:
+   - When diagnosing dispatch, construct the concrete application class and
+     enable its debug output before execution:
      ```pascal
-     (App as TCLIApplication).DebugMode := True;
+     Application := TCLIApplication.Create('MyApp', '1.0.0');
+     Application.DebugMode := True;
      ```
+     `DebugMode` is a `TCLIApplication` property and is not exposed by the
+     `ICLIApplication` returned from the factory. Manage the concrete
+     instance's lifetime normally.
 
 2. **Parameter Errors**
    - Check parameter format:
@@ -961,8 +821,10 @@ myapp test               # --flag is false
      ```
 
 3. **Console Colors Not Working**
-   - Windows: Check if ANSI support is enabled
-   - Unix/Linux: Verify terminal supports colors
+   - Windows foreground and background colours use the console API
+   - Unix-like systems require a terminal that interprets ANSI colour codes
+   - Cursor movement and position helpers require ANSI-compatible terminal
+     behaviour on every platform
    - Always reset colors:
      ```pascal
      TConsole.SetForegroundColor(ccRed);
@@ -1031,21 +893,7 @@ myapp test               # --flag is false
 '╚═╝' // Bottom border
 ```
 
-
-
-## Getting Help
-
-- Use `--help-complete` for comprehensive documentation
-- Check command-specific help with `<command> --help`
-- Enable debug mode for troubleshooting
-- Refer to the technical documentation for development details
-
-## Summary
-
-This manual has walked you through building and extending CLI applications using the Free Pascal CLI Framework. By following these guidelines and best practices, you can create robust and user-friendly command-line tools.
-Happy Coding!
-
-## Cheat Sheet
+## API Cheat Sheet
 
 Essential commands for building CLI applications:
 
@@ -1232,7 +1080,7 @@ the completion engine.
 
 ## PowerShell Tab Completion
 
-### Overview
+### PowerShell Behaviour
 The CLI now provides robust, context-aware PowerShell tab completion for all commands, subcommands, and flags. This matches the experience of modern CLI tools (e.g., Go's Cobra, git, etc.).
 
 ### How to Enable
@@ -1268,4 +1116,13 @@ PS> ./SubCommandDemo.exe repo <Tab>
 - Uses `Register-ArgumentCompleter`; PowerShell 7+ additionally receives
   native executable registration
 - The completion script is dynamically generated from the CLI command tree.
-- Bash completion is also supported (see README).
+- Bash completion is also supported (see [Bash Completion](#bash-completion)).
+
+## Where to Go Next
+
+- Generate a maintainable project layout with the
+  [code-generator guide](codegen.md).
+- Look up exact signatures in the [API reference](api-reference.md).
+- Read the [technical documentation](technical-docs.md) when changing parser,
+  ownership, help, or completion internals.
+- Explore the focused [example programs](../examples/).

--- a/packages/lazarus/cli_fp.lpk
+++ b/packages/lazarus/cli_fp.lpk
@@ -14,7 +14,7 @@
     </CompilerOptions>
     <Description Value="# CLI Framework for Free Pascal 🚀
 
-A robust and fast Free Pascal framework for building professional CLI applications. Create powerful command-line tools with hierarchical commands and comprehensive help systems - all with type-safe, object-oriented design."/>
+A robust and fast Free Pascal framework for building professional CLI applications. Create powerful command-line tools with hierarchical commands, typed parameter metadata and validation, and comprehensive help systems using an object-oriented design."/>
     <License Value="MIT License
 
 Copyright (c) 2025 CLI Framework for Free Pascal, ikelaiah
@@ -36,7 +36,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. "/>
-    <Version Major="1" Minor="3" Release="0"/>
+    <Version Major="1" Minor="3" Release="1"/>
     <Files>
       <Item>
         <Filename Value="..\..\src\cli.application.pas"/>


### PR DESCRIPTION
# Pull Request: Release v1.3.1 - Documentation Onboarding and Accuracy

**Target Release:** v1.3.1

**Release Date:** July 28, 2026

## Summary

This PR makes `cli-fp` substantially easier to approach for developers who
are new to the library or to Free Pascal. It introduces a verified
first-success path, explains the Object Pascal conventions used by the
project, improves navigation across the documentation set, and corrects
platform and API details discovered during the documentation audit.

This is a documentation-focused patch release. It does not change framework
runtime behaviour, public APIs, generator schemas, or generated output.

## Type of Change

- [x] Documentation improvement
- [x] Documentation correction
- [x] Documentation and example verification
- [ ] New framework feature
- [ ] Breaking change

## README Onboarding

- [x] Add goal-based “Start Here” routes for new FPC developers, new `cli-fp`
  users, existing Pascal applications, Lazarus users, and API readers.
- [x] Add Free Pascal installation and split-package guidance.
- [x] Add a five-minute generated CLI that reaches a working native
  executable before introducing framework internals.
- [x] Show how to replace a generated command implementation and run it.
- [x] Add a concise Free Pascal and Object Pascal orientation.
- [x] Explain root, named, and combined CLI application shapes.
- [x] Present implemented capabilities through a focused feature tour.

## Documentation Navigation

- [x] Add `docs/README.md` as a goal-based documentation landing page.
- [x] Map examples to the concepts they demonstrate.
- [x] Add repository-layout orientation for new contributors.
- [x] Distinguish current guides from release notes and dated test records.
- [x] Add navigation between the user manual, generator guide, API reference,
  technical documentation, and completion guides.
- [x] Mark advanced references with their intended audience.

## Manual and Generator Guides

- [x] Replace the user manual’s duplicated opening cheat sheet with
  prerequisites and learning paths.
- [x] Retain one API cheat sheet for quick lookup.
- [x] Clarify root-command, parameter retrieval, help, debug, and console
  terminology.
- [x] Expand the generator guide with verified Bash and PowerShell first-build
  paths.
- [x] Explain the roles of `.lpr`, generated units, user-owned command units,
  `clifp.json`, and FPC unit-search paths.

## Accuracy Corrections

- [x] Distinguish typed parameter metadata and validation from string-based
  value retrieval.
- [x] Clarify the FCL JSON dependency used by `cli-fp-gen`.
- [x] Quote PowerShell `-Fu` arguments where required.
- [x] Separate CI-tested platforms from expected but currently untested Unix
  compatibility.
- [x] Describe Windows console colour handling and ANSI-dependent cursor
  operations accurately.
- [x] Expand public API excerpts and document omitted testing and disabled
  callback surfaces.
- [x] Preserve the distinct application, command-level, complete-help,
  version, and completion-script scopes.

## Compatibility

No application or generator migration is required:

- framework source is unchanged;
- public API signatures are unchanged;
- `clifp.json` schema version 1 is unchanged;
- generated project ownership rules are unchanged; and
- existing applications do not need to be rebuilt for this documentation
  release.

## Verification

- [x] Framework suite: 38 tests, 0 failures.
- [x] Full Windows code-generator suite.
- [x] Documented generator build and generated-application compile.
- [x] Documented `TGreetCommand.Execute` implementation and
  `Hello, Ada!` runtime result.
- [x] General-help and command-help runtime smoke tests.
- [x] `RootCommandDemo` compile and runtime smoke tests.
- [x] Lazarus runtime package build with metadata at `1.3.1`.
- [x] All local targets and heading anchors across 30 Markdown files.
- [x] Balanced fenced code blocks across 30 Markdown files.
- [x] `git diff --check`.
- [ ] GitHub Actions after the PR is opened.

## Release Readiness

- [x] Changelog entry prepared under `Unreleased`.
- [x] v1.3.1 release notes prepared.
- [x] Finalize the release date.
- [x] Update version metadata to `1.3.1` where required.
- [ ] Confirm GitHub Actions on Linux and Windows.
- [x] Move the changelog entry from `Unreleased` to a dated `1.3.1` section.

After merge, create the `v1.3.1` tag and publish the prepared release notes.
