### PR TITLE
docs: constrain homepage hero image

### DIFF
--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -1,0 +1,7 @@
+/* Keep the README hero inside DocKit's content column at every viewport width. */
+.prose[data-homepage="true"] > p:first-of-type > img:only-child {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  height: auto;
+}

--- a/docs/dockit.json
+++ b/docs/dockit.json
@@ -8,7 +8,8 @@
   },
   "theme": {
     "preset": "purple",
-    "style": "classic"
+    "style": "classic",
+    "custom_css": "docs/assets/custom.css"
   },
   "homepage": {
     "capabilities": [


### PR DESCRIPTION
## Summary

- add DocKit's supported repository-local custom stylesheet
- constrain the homepage hero SVG to the content column while preserving its aspect ratio
- keep the fix scoped to the README homepage hero

## Validation

- reproduced the overflow against the generated DocKit site before the fix
- `dockit-fp check`
- `dockit-fp audit --strict`
- DocKit v0.18.0 build
- generated stylesheet load-order and responsive-rule assertions
- local HTTP checks for all published routes and assets

No runtime/source code changed.