### PR TITLE
docs: clarify v1.4.1 command context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-09-09
+
+### Documentation
+
+- Corrected the reader-facing class-based command model: published recipes now
+  distinguish command descendants, their option-owning instances, and the
+  application registration that dispatches `Execute`.
+- Reworked root, named, nested, option, terminal, progress, exit-code, and
+  debug examples so each has declarations or explicit fragment context.
+- Labelled public-reference signatures and technical implementation excerpts
+  by scope; no runtime API, parser, or generator behavior changed.
+
 ## [1.4.0] - 2026-09-09
 
 ### Documentation
@@ -431,7 +443,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README with quick start guide
 - System requirements and compatibility information
 
-[Unreleased]: https://github.com/ikelaiah/cli-fp/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/ikelaiah/cli-fp/compare/v1.4.1...HEAD
+[1.4.1]: https://github.com/ikelaiah/cli-fp/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/ikelaiah/cli-fp/compare/v1.3.3...v1.4.0
 [1.3.3]: https://github.com/ikelaiah/cli-fp/compare/v1.3.2...v1.3.3
 [1.3.2]: https://github.com/ikelaiah/cli-fp/compare/v1.3.1...v1.3.2

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Lazarus](https://img.shields.io/badge/Lazarus-package-60A5FA.svg)](https://github.com/ikelaiah/cli-fp/blob/main/packages/lazarus/cli_fp.lpk)
 ![Supports Windows](https://img.shields.io/badge/support-Windows-F59E0B?logo=Windows)
 ![Supports Linux](https://img.shields.io/badge/support-Linux-F59E0B?logo=Linux)
-[![Version](https://img.shields.io/badge/version-1.4.0-8B5CF6.svg)](https://github.com/ikelaiah/cli-fp/blob/main/CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.4.1-8B5CF6.svg)](https://github.com/ikelaiah/cli-fp/blob/main/CHANGELOG.md)
 [![Documentation](https://img.shields.io/badge/Docs-Website-brightgreen.svg)](https://ikelaiah.github.io/cli-fp/)
 [![Tests](https://github.com/ikelaiah/cli-fp/actions/workflows/tests.yml/badge.svg)](https://github.com/ikelaiah/cli-fp/actions/workflows/tests.yml)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -100,7 +100,19 @@ buildable, test results do not depend on stale compiler units, diagnostics do
 not expose password values, and the test suite provides a dependable safety
 net for the v1.4.0 documentation work.
 
-## v1.4.0 — Documentation and Developer Learning Experience
+## v1.4.1 — Documentation Accuracy Patch (completed 2026-09-09)
+
+- Correct published snippets so the class-based command relationship is
+  explicit: a `TBaseCommand` descendant, its option-owning instance, and the
+  `ICLIApplication` registration that invokes `Execute`.
+- Keep the v1.4.0 learning path and executable QuickStart intact while making
+  recipes and reference fragments safe to read in context.
+
+**Maintenance outcome:** readers can follow the current public API without
+inventing command, application, or terminal variables that the documentation
+did not define.
+
+## v1.4.0 — Documentation and Developer Learning Experience (completed)
 
 - Publish a task-oriented documentation path that starts with a compiling
   example, distinguishes root, named, and nested command shapes, and makes

--- a/docs/RELEASE_NOTES_v1.4.1.md
+++ b/docs/RELEASE_NOTES_v1.4.1.md
@@ -1,0 +1,24 @@
+# Release Notes - cli-fp v1.4.1
+
+`v1.4.1` is a documentation-accuracy patch. It does not add or change a
+runtime API, parser behavior, generator behavior, or the supported
+class-based command model.
+
+## What changed
+
+- Reader-facing Pascal snippets now explicitly distinguish a developer-defined
+  `TBaseCommand` descendant, its concrete command instance, and its
+  registration with `ICLIApplication`.
+- How-To, Commands, Options, and Terminal guidance now state whether a block
+  is a complete command pattern, a program-setup fragment, or an
+  `Execute`-method fragment, including required units and variable scope.
+- The API reference labels signature declarations and setup context; technical
+  documentation labels its implementation excerpts as non-standalone source
+  context.
+
+## Upgrade notes
+
+No source migration is required. Existing applications, generator projects,
+and the public runtime API remain unchanged.
+
+See the [changelog](../CHANGELOG.md) for the complete release history.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -6,7 +6,9 @@
 Use this page to look up the current public, application-facing API. For a
 complete program, start with [your first CLI](getting-started.md). The public
 units in [`src/`](https://github.com/ikelaiah/cli-fp/tree/main/src) are the
-authoritative declarations.
+authoritative declarations. Signature blocks below are API declarations;
+application code is always labelled as a program-setup fragment and names its
+variables or states the command pattern it depends on.
 
 ## Units to use
 
@@ -34,10 +36,20 @@ Use the two-argument overload for a command-first application. Use the
 three-argument overload when an unnamed root command should run for
 `myapp [options]`.
 
+The following **program-setup fragment** needs `CLI.Interfaces` and
+`CLI.Application`. It assumes `TRootCommand` is a declared `TBaseCommand`
+descendant with an overridden `Execute`; `Root` is the instance passed to the
+factory.
+
 ```pascal
-App := CreateCLIApplication('myapp', '1.0.0', Root);
-App.RegisterCommand(About);
-Halt(App.Execute);
+var
+  App: ICLIApplication;
+  Root: TRootCommand;
+begin
+  Root := TRootCommand.Create('', 'Run the default action');
+  App := CreateCLIApplication('myapp', '1.0.0', Root);
+  Halt(App.Execute);
+end.
 ```
 
 `ICLIApplication` exposes:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -3,7 +3,20 @@
 [Start here](getting-started.md) · [How do I...?](how-to.md) ·
 [Options](options.md) · [Limitations](limitations.md)
 
-Choose the smallest command shape that matches how people invoke the program.
+In normal v1.4.x code, a command is an object you define by subclassing
+`TBaseCommand`. The object owns its registered options; the application owns
+the command tree and calls the selected object's `Execute` method.
+
+```text
+TBaseCommand
+  └── your command class (for example, TGreetCommand)
+      ├── Execute
+      └── options registered on its instance
+your command instance
+  └── registered with ICLIApplication
+```
+
+Choose the smallest shape that matches how people invoke the program.
 
 | Shape | Invocation | Use it when |
 | --- | --- | --- |
@@ -13,54 +26,150 @@ Choose the smallest command shape that matches how people invoke the program.
 
 ## Root command
 
-Pass an unnamed command to the three-argument `CreateCLIApplication` overload:
+An unnamed descendant is the default action. This complete **command pattern**
+defines `TRootCommand`; its empty name is supplied when the instance is made.
 
 ```pascal
-Root := THelloCommand.Create('', 'Print a greeting');
-App := CreateCLIApplication('hello', '1.0.0', Root);
+uses
+  CLI.Command;
+
+type
+  TRootCommand = class(TBaseCommand)
+  public
+    function Execute: Integer; override;
+  end;
+
+function TRootCommand.Execute: Integer;
+begin
+  WriteLn('Running the default action');
+  Result := 0;
+end;
 ```
 
-The root command can have options, and named commands can still be registered
-alongside it. Its options only belong to the root action; they are not global
-options inherited by named commands.
+This **program-setup fragment** needs `CLI.Interfaces` and `CLI.Application`.
+It creates the `Root` object, registers its option on that object, and passes
+the object to the three-argument factory:
+
+```pascal
+var
+  App: ICLIApplication;
+  Root: TRootCommand;
+begin
+  Root := TRootCommand.Create('', 'Run the default action');
+  Root.AddFlag('-v', '--verbose', 'Show detailed output');
+  App := CreateCLIApplication('hello', '1.0.0', Root);
+  Halt(App.Execute);
+end.
+```
+
+The root's `Execute` runs for `hello [options]`. Its options only belong to
+the root action; they are not global options inherited by named commands.
 
 ## Named command
 
-Create a normally named command and register it with the application:
+A named descendant is a separately selectable action. This complete
+**command pattern** defines the `TGreetCommand` class and its `Execute` method:
 
 ```pascal
-Greet := TGreetCommand.Create('greet', 'Print a greeting');
-Greet.AddStringParameter('-n', '--name', 'Name to greet', False, 'World');
-App := CreateCLIApplication('tool', '1.0.0');
-App.RegisterCommand(Greet);
+uses
+  CLI.Command;
+
+type
+  TGreetCommand = class(TBaseCommand)
+  public
+    function Execute: Integer; override;
+  end;
+
+function TGreetCommand.Execute: Integer;
+begin
+  WriteLn('Hello from greet');
+  Result := 0;
+end;
 ```
 
-This accepts `tool greet --name Ada`. If a command has no root command,
-calling `tool` without a named command shows application help instead of
-running an action.
+This **program-setup fragment** creates the `Greet` instance, gives that
+instance its `--name` option, and registers it with `App`. It needs
+`CLI.Interfaces` and `CLI.Application`:
+
+```pascal
+var
+  App: ICLIApplication;
+  Greet: TGreetCommand;
+begin
+  App := CreateCLIApplication('tool', '1.0.0');
+  Greet := TGreetCommand.Create('greet', 'Print a greeting');
+  Greet.AddStringParameter('-n', '--name', 'Name to greet', False, 'World');
+  App.RegisterCommand(Greet);
+  Halt(App.Execute);
+end.
+```
+
+This accepts `tool greet --name Ada`. With no root command, `tool` by itself
+shows application help instead of running an action.
 
 ## Subcommand
 
-Attach a command to another command before registering the top-level command:
+A nested CLI has a parent command object and a child command object. Both
+descend from `TBaseCommand` and must implement `Execute`; the parent can act
+as a group even when its method only returns success:
 
 ```pascal
-Repo := TRepoCommand.Create('repo', 'Repository operations');
-Clone := TCloneCommand.Create('clone', 'Clone a repository');
-Clone.AddUrlParameter('-u', '--url', 'Repository URL', True);
-Repo.AddSubCommand(Clone);
-App.RegisterCommand(Repo);
+uses
+  CLI.Command;
+
+type
+  TRepoCommand = class(TBaseCommand)
+  public
+    function Execute: Integer; override;
+  end;
+
+  TCloneCommand = class(TBaseCommand)
+  public
+    function Execute: Integer; override;
+  end;
+
+function TRepoCommand.Execute: Integer;
+begin
+  Result := 0;
+end;
+
+function TCloneCommand.Execute: Integer;
+begin
+  WriteLn('Cloning a repository');
+  Result := 0;
+end;
 ```
 
-This accepts `tool repo clone --url https://example.com/project.git`. A command
-that is only a group has subcommands but does not receive options from its
-children.
+This **program-setup fragment** builds `tool repo clone`. It needs
+`CLI.Interfaces` and `CLI.Application`; `Clone`, not `Repo`, owns `--url`:
+
+```pascal
+var
+  App: ICLIApplication;
+  Repo: TRepoCommand;
+  Clone: TCloneCommand;
+begin
+  App := CreateCLIApplication('tool', '1.0.0');
+  Repo := TRepoCommand.Create('repo', 'Repository operations');
+  Clone := TCloneCommand.Create('clone', 'Clone a repository');
+  Clone.AddUrlParameter('-u', '--url', 'Repository URL', True);
+  Repo.AddSubCommand(Clone);
+  App.RegisterCommand(Repo);
+  Halt(App.Execute);
+end.
+```
+
+This accepts `tool repo clone --url https://example.com/project.git`. A group
+does not receive options from its children. For a runnable nested example, see
+[SubCommandDemo](https://github.com/ikelaiah/cli-fp/tree/main/examples/SubCommandDemo).
 
 ## Help and exit codes
 
 `tool --help` shows application help. `tool greet --help` shows the selected
 command. `--version` is an application-level request when used as the first
-argument. Return `0` from `Execute` for success and a non-zero integer for an
-application failure; `Halt(App.Execute)` forwards it to the shell.
+argument. Return `0` from a command's `Execute` for success and a non-zero
+integer for an application failure; the setup fragments use `Halt(App.Execute)`
+to forward that result to the shell.
 
 See [How do I return a non-zero exit code?](how-to.md#how-do-i-return-a-non-zero-exit-code)
-for the smallest pattern.
+for a focused method pattern.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,6 +8,11 @@ complete program below is also the repository's
 [QuickStartDemo](https://github.com/ikelaiah/cli-fp/tree/main/examples/QuickStartDemo),
 which is compiled by the Windows and Linux example smoke checks.
 
+The program follows the normal v1.4.x ownership model: `THelloCommand`
+descends from `TBaseCommand`, `Main` is its instance and owns `--name`, and
+`App` is the `ICLIApplication` that parses the invocation and calls
+`Main.Execute`.
+
 ```pascal
 program QuickStartDemo;
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -1,186 +1,225 @@
 # How do I...?
 
 Short, supported recipes for common `cli-fp` tasks. Start with
-[your first program](getting-started.md) if the class-based API is new to you.
-Each recipe shows the smallest useful piece; linked guides supply the surrounding
-program structure.
+[your first program](getting-started.md) for the canonical compiled program.
+
+## The command model used by every recipe
+
+Normal v1.4.x applications are class-based. You define a descendant, create
+an object of that class, register its options on that object, then register the
+object with the application:
+
+```text
+TBaseCommand
+  └── TGreetCommand
+      ├── Execute
+      └── registered options
+TGreetCommand instance
+  └── registered with ICLIApplication
+```
+
+This complete **command pattern** defines the developer-owned command. It is
+not a whole program; the setup fragment immediately below creates and
+registers its `Greet` instance.
+
+```pascal
+uses
+  CLI.Command;
+
+type
+  TGreetCommand = class(TBaseCommand)
+  public
+    function Execute: Integer; override;
+  end;
+
+function TGreetCommand.Execute: Integer;
+var
+  PersonName: string;
+begin
+  if not GetParameterValue('--name', PersonName) then
+    PersonName := 'World';
+  WriteLn('Hello, ', PersonName, '!');
+  Result := 0;
+end;
+```
+
+This **program-setup fragment** supplies the instance and application used by
+the option recipes below. Put it in a program that also contains the command
+pattern above and uses `CLI.Interfaces` and `CLI.Application`.
+
+```pascal
+var
+  App: ICLIApplication;
+  Greet: TGreetCommand;
+begin
+  App := CreateCLIApplication('hello', '1.0.0');
+  Greet := TGreetCommand.Create('greet', 'Print a greeting');
+  Greet.AddStringParameter('-n', '--name', 'Name to greet', False, 'World');
+  App.RegisterCommand(Greet);
+  Halt(App.Execute);
+end.
+```
+
+The `TGreetCommand` instance owns `--name`; its `Execute` method retrieves
+that value after the application has parsed and validated the command line.
 
 ## How do I create the smallest CLI?
 
-Use an unnamed root command and pass it to `CreateCLIApplication`:
-
-```pascal
-Main := THelloCommand.Create('', 'Print a greeting');
-App := CreateCLIApplication('hello', '1.0.0', Main);
-Halt(App.Execute);
-```
-
-See the complete, compiled [QuickStartDemo](getting-started.md).
+Use the complete, compiled [QuickStartDemo](getting-started.md). It supplies
+an unnamed root-command descendant and passes that object to the three-argument
+`CreateCLIApplication` overload.
 
 ## How do I create a root/default command?
 
-Give a `TBaseCommand` descendant an empty name. Its `Execute` method runs for
-`myapp [options]`:
+Define the root command exactly like `TGreetCommand`, but give its instance an
+empty name. This setup fragment assumes `TRootCommand` is your declared
+`TBaseCommand` descendant with an overridden `Execute` method:
 
 ```pascal
-Root := TMyRootCommand.Create('', 'Run the default action');
-App := CreateCLIApplication('myapp', '1.0.0', Root);
+var
+  App: ICLIApplication;
+  Root: TRootCommand;
+begin
+  Root := TRootCommand.Create('', 'Run the default action');
+  Root.AddFlag('-v', '--verbose', 'Show detailed output');
+  App := CreateCLIApplication('myapp', '1.0.0', Root);
+  Halt(App.Execute);
+end.
 ```
 
-Root options are not inherited by named commands. See [command shapes](commands.md).
+Its `Execute` method runs for `myapp [options]`. Root options are not inherited
+by named commands; see [command shapes](commands.md).
 
 ## How do I add a named command?
 
-```pascal
-Greet := TGreetCommand.Create('greet', 'Print a greeting');
-App.RegisterCommand(Greet);
-```
-
-This creates `myapp greet`. Create the application without a root command for
-a command-first CLI.
+The `TGreetCommand` pattern and setup at the top of this page create
+`hello greet --name Ada`. For a command-first application, call the two-argument
+factory, create the named command object, register its options on that object,
+then call `App.RegisterCommand(Greet)`.
 
 ## How do I add a subcommand?
 
+A parent and child are both command objects. This **setup fragment** assumes
+`TRepoCommand` and `TCloneCommand` are declared `TBaseCommand` descendants,
+each with its own `Execute` override; it registers only the top-level object:
+
 ```pascal
-Repo := TRepoCommand.Create('repo', 'Repository operations');
-Clone := TCloneCommand.Create('clone', 'Clone a repository');
-Repo.AddSubCommand(Clone);
-App.RegisterCommand(Repo);
+var
+  App: ICLIApplication;
+  Repo: TRepoCommand;
+  Clone: TCloneCommand;
+begin
+  App := CreateCLIApplication('tool', '1.0.0');
+  Repo := TRepoCommand.Create('repo', 'Repository operations');
+  Clone := TCloneCommand.Create('clone', 'Clone a repository');
+  Clone.AddUrlParameter('-u', '--url', 'Repository URL', True);
+  Repo.AddSubCommand(Clone);
+  App.RegisterCommand(Repo);
+  Halt(App.Execute);
+end.
 ```
 
-This creates `myapp repo clone`. See [commands](commands.md) for the complete
-relationship.
+This creates `tool repo clone --url https://example.com/project.git`. The
+`Clone` object owns `--url`; the parent is only the command group. See
+[commands](commands.md) for the full root/named/nested comparison.
 
-## How do I add a string option?
+## How do I add options?
+
+Each registration below is a **program-setup fragment** placed immediately
+after `Greet := TGreetCommand.Create(...)` in the setup at the top of this
+page. `Greet` is therefore the concrete `TGreetCommand` instance that owns
+the registered option.
+
+### String, integer, and float
 
 ```pascal
-Command.AddStringParameter('-n', '--name', 'Name to greet', False, 'World');
+Greet.AddStringParameter('-n', '--name', 'Name to greet', False, 'World');
+Greet.AddIntegerParameter('-c', '--count', 'Number of runs', True);
+Greet.AddFloatParameter('-r', '--rate', 'Processing rate', False, '1.0');
 ```
 
-The final argument is the default value. Omit it for an optional parameter
-without a default.
-
-## How do I add an integer or float option?
+### Required, default, flag, and enum
 
 ```pascal
-Command.AddIntegerParameter('-c', '--count', 'Number of runs', True);
-Command.AddFloatParameter('-r', '--rate', 'Processing rate', False, '1.0');
-```
-
-Values are validated before `Execute`; convert the retrieved string with
-`TryStrToInt` or `TryStrToFloat`.
-
-## How do I make an option required?
-
-Pass `True` in the `Required` position:
-
-```pascal
-Command.AddStringParameter('-f', '--file', 'Input file', True);
-```
-
-The framework reports a missing required option and shows command help before
-it calls `Execute`.
-
-## How do I give an option a default?
-
-```pascal
-Command.AddStringParameter('-o', '--output', 'Output file', False, 'out.txt');
-```
-
-`GetParameterValue` returns the default string when the user omitted the
-option.
-
-## How do I add a Boolean flag?
-
-```pascal
-Command.AddFlag('-v', '--verbose', 'Show detailed output');
-```
-
-It is `false` by default and `true` when present. For an explicit
-`--colour true|false` value, use `AddBooleanParameter` instead.
-
-## How do I add an enum option?
-
-```pascal
-Command.AddEnumParameter('-l', '--level', 'Log level',
+Greet.AddStringParameter('-f', '--file', 'Input file', True);
+Greet.AddStringParameter('-o', '--output', 'Output file', False, 'out.txt');
+Greet.AddFlag('-v', '--verbose', 'Show detailed output');
+Greet.AddEnumParameter('-l', '--level', 'Log level',
   'debug|info|warn|error', False, 'info');
 ```
 
-Enum matching is case-insensitive and built-in completion suggests the listed
-values.
-
-## How do I accept a path?
+### Path, URL, and password
 
 ```pascal
-Command.AddPathParameter('-p', '--path', 'Target directory', True);
+Greet.AddPathParameter('-p', '--path', 'Target directory', True);
+Greet.AddUrlParameter('-u', '--url', 'Repository URL', True);
+Greet.AddPasswordParameter('-k', '--api-key', 'API key', True);
 ```
 
-This accepts a path-shaped string; it does not check that the path exists.
+The framework validates registered values before it calls the selected
+command's `Execute`. Paths are still strings rather than existence checks;
+never print a retrieved password. See [options](options.md) for every kind.
 
-## How do I accept a URL?
+## How do I retrieve and convert a value?
 
-```pascal
-Command.AddUrlParameter('-u', '--url', 'Repository URL', True);
-```
-
-The current validator accepts `http://`, `https://`, `git://`, and `ssh://`
-prefixes.
-
-## How do I accept a sensitive/password value?
+Put lookup code inside the descendant that owns the option. This replacement
+for `TGreetCommand.Execute` uses the `--count` and `--verbose` options
+registered on the `Greet` instance above; it needs `SysUtils` for
+`TryStrToInt` and `SameText`.
 
 ```pascal
-Command.AddPasswordParameter('-k', '--api-key', 'API key', True);
-```
-
-Do not print or log the retrieved string. Framework debug output redacts
-registered password values, but your own output does not.
-
-## How do I retrieve a parameter inside `Execute`?
-
-```pascal
-var Name: string;
+function TGreetCommand.Execute: Integer;
+var
+  RawCount: string;
+  RawVerbose: string;
+  Count: Integer;
 begin
-  if GetParameterValue('--name', Name) then
-    WriteLn('Hello, ', Name);
+  if GetParameterValue('--count', RawCount) and
+     TryStrToInt(RawCount, Count) then
+    WriteLn('Count: ', Count);
+
+  if GetParameterValue('--verbose', RawVerbose) and
+     SameText(RawVerbose, 'true') then
+    WriteLn('Verbose mode');
+
+  Result := 0;
 end;
 ```
 
-Use either the short or long flag registered on that command.
-
-## How do I convert validated values to Pascal types?
-
-```pascal
-if GetParameterValue('--count', RawCount) and TryStrToInt(RawCount, Count) then
-  WriteLn(Count);
-
-if GetParameterValue('--verbose', RawVerbose) and
-   SameText(RawVerbose, 'true') then
-  WriteLn('Verbose mode');
-```
-
-The current public lookup API is string-based; [options](options.md) explains
-why conversion remains necessary.
+`GetParameterValue` is protected, so it belongs in the command class—not the
+program setup. Values remain strings after validation; use `TryStrToFloat` for
+a float. An absent `AddFlag` normally supplies `false`.
 
 ## How do I return a non-zero exit code?
 
-Return it from `Execute`, then pass the application's result to `Halt`:
+Set `Result` in the command's `Execute`, then let the application return it to
+the shell. This complete **command-method fragment** assumes
+`TCheckCommand = class(TBaseCommand)` is declared in the same unit:
 
 ```pascal
 function TCheckCommand.Execute: Integer;
+var
+  InputFile: string;
 begin
-  if not CheckInputs then
+  if not GetParameterValue('--file', InputFile) then
     Exit(1);
+  WriteLn('Checking ', InputFile);
   Result := 0;
 end;
-
-// Program body
-Halt(App.Execute);
 ```
+
+At the program boundary, use `Halt(App.Execute)`—not `Halt` inside `Execute`.
+Here `App` is the `ICLIApplication` variable created in a program-setup
+fragment such as the one at the top of this page.
 
 ## How do I print coloured output?
 
+Inside a command's `Execute`, import `CLI.Console` and call the `TConsole`
+class directly; there is no console object to construct:
+
 ```pascal
-uses CLI.Console;
+uses
+  CLI.Console;
 
 TConsole.WriteLn('Created project', ccGreen);
 TConsole.WriteLn('Could not create project', ccRed);
@@ -191,31 +230,59 @@ See [terminal output](terminal.md) and the runnable
 
 ## How do I display a spinner?
 
+This complete **`Execute`-method fragment** belongs to a declared
+`TDownloadCommand = class(TBaseCommand)`. Its command unit needs
+`CLI.Interfaces` and `CLI.Progress`:
+
 ```pascal
-Spinner := CreateSpinner(ssLine);
-Spinner.Start;
-try
-  Work;
-finally
-  Spinner.Stop;
+function TDownloadCommand.Execute: Integer;
+var
+  Spinner: IProgressIndicator;
+begin
+  Spinner := CreateSpinner(ssLine);
+  Spinner.Start;
+  try
+    Spinner.Update(0, 'Downloading');
+    // Perform the download here.
+  finally
+    Spinner.Stop;
+  end;
+  Result := 0;
 end;
 ```
 
-Use an `IProgressIndicator` variable and always stop it in `finally`.
+Always stop the indicator in `finally`.
 
 ## How do I display progress?
 
+This complete **`Execute`-method fragment** belongs to a declared
+`TBatchCommand = class(TBaseCommand)`. Its command unit needs `SysUtils`,
+`CLI.Interfaces`, and `CLI.Progress`:
+
 ```pascal
-Bar := CreateProgressBar(Total);
-Bar.Start;
-try
-  Bar.Update(Current, 'Working');
-finally
-  Bar.Stop;
+function TBatchCommand.Execute: Integer;
+var
+  Bar: IProgressIndicator;
+  Index: Integer;
+  Total: Integer;
+begin
+  Total := 3;
+  Bar := CreateProgressBar(Total);
+  Bar.Start;
+  try
+    for Index := 1 to Total do
+    begin
+      // Process item Index here.
+      Bar.Update(Index, Format('Processed %d of %d', [Index, Total]));
+    end;
+  finally
+    Bar.Stop;
+  end;
+  Result := 0;
 end;
 ```
 
-Use a progress bar when `Total` is known; otherwise use a spinner.
+Use a progress bar when the total is known; otherwise use a spinner.
 
 ## How do I generate Bash completion?
 
@@ -254,11 +321,17 @@ user-owned command units. See the [generator guide](codegen.md).
 
 ## How do I inspect/debug argument parsing?
 
-`DebugMode` is on the concrete `TCLIApplication`, not `ICLIApplication`:
+`DebugMode` is on the concrete `TCLIApplication`, not `ICLIApplication`. This
+**program-setup fragment** declares and creates the `App` it casts; it needs
+`CLI.Interfaces` and `CLI.Application`:
 
 ```pascal
-App := CreateCLIApplication('myapp', '1.0.0');
-(App as TCLIApplication).DebugMode := True;
+var
+  App: ICLIApplication;
+begin
+  App := CreateCLIApplication('myapp', '1.0.0');
+  (App as TCLIApplication).DebugMode := True;
+end;
 ```
 
 Use it only while diagnosing an invocation, and never use debug output as a

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -2,7 +2,7 @@
 
 [How do I...?](how-to.md) · [Commands](commands.md) · [Options](options.md)
 
-These are current v1.4.0 boundaries verified against the public source and
+These are current v1.4.1 boundaries verified against the public source and
 tests. They are intentionally easy to find so a limitation does not look like
 an undocumented feature.
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -3,37 +3,71 @@
 [Start here](getting-started.md) · [How do I...?](how-to.md) ·
 [API reference](api-reference.md) · [Limitations](limitations.md)
 
-Register options on the command that uses them. Parsing and validation happen
-before `Execute`; retrieve accepted values with `GetParameterValue` inside the
-command.
+Options belong to a command object, not to the application globally. Define a
+`TBaseCommand` descendant, create its instance during program setup, register
+options on that instance, then retrieve accepted values inside that class's
+`Execute` method.
 
 ## Register an option
 
-The registration helpers are methods of `TBaseCommand`:
+This complete **command pattern** defines an option-owning command. The setup
+fragment creates its `Cmd` instance; every registration below is placed after
+that constructor call and therefore acts on a real `TOptionsCommand` object.
 
-| Need | Registration |
+```pascal
+uses
+  CLI.Command;
+
+type
+  TOptionsCommand = class(TBaseCommand)
+  public
+    function Execute: Integer; override;
+  end;
+
+function TOptionsCommand.Execute: Integer;
+begin
+  Result := 0;
+end;
+```
+
+```pascal
+var
+  Cmd: TOptionsCommand;
+begin
+  Cmd := TOptionsCommand.Create('configure', 'Configure the application');
+  // Register Cmd options here, then register Cmd with the application.
+end;
+```
+
+In the following table, `Cmd` means that exact `TOptionsCommand` instance.
+
+| Need | Registration on `Cmd` |
 | --- | --- |
-| Text | `AddStringParameter('-n', '--name', 'Name', False, 'World')` |
-| Integer | `AddIntegerParameter('-c', '--count', 'Count', True)` |
-| Float | `AddFloatParameter('-r', '--rate', 'Rate', False, '1.0')` |
-| Presence flag | `AddFlag('-v', '--verbose', 'Verbose output')` |
-| Explicit Boolean | `AddBooleanParameter('-c', '--color', 'Use colour', False, 'true')` |
-| Choice | `AddEnumParameter('-l', '--level', 'Level', 'debug|info|warn', False, 'info')` |
-| Path | `AddPathParameter('-p', '--path', 'Target path', True)` |
-| URL | `AddUrlParameter('-u', '--url', 'Repository URL', True)` |
-| Password | `AddPasswordParameter('-k', '--api-key', 'API key', True)` |
-| Date/time | `AddDateTimeParameter('-t', '--time', 'Start time')` |
-| Comma-separated items | `AddArrayParameter('-a', '--items', 'Items')` |
+| Text | `Cmd.AddStringParameter('-n', '--name', 'Name', False, 'World')` |
+| Integer | `Cmd.AddIntegerParameter('-c', '--count', 'Count', True)` |
+| Float | `Cmd.AddFloatParameter('-r', '--rate', 'Rate', False, '1.0')` |
+| Presence flag | `Cmd.AddFlag('-v', '--verbose', 'Verbose output')` |
+| Explicit Boolean | `Cmd.AddBooleanParameter('-c', '--color', 'Use colour', False, 'true')` |
+| Choice | `Cmd.AddEnumParameter('-l', '--level', 'Level', 'debug|info|warn', False, 'info')` |
+| Path | `Cmd.AddPathParameter('-p', '--path', 'Target path', True)` |
+| URL | `Cmd.AddUrlParameter('-u', '--url', 'Repository URL', True)` |
+| Password | `Cmd.AddPasswordParameter('-k', '--api-key', 'API key', True)` |
+| Date/time | `Cmd.AddDateTimeParameter('-t', '--time', 'Start time')` |
+| Comma-separated items | `Cmd.AddArrayParameter('-a', '--items', 'Items')` |
 
 `True` in the required position makes an option required. An optional option
-with a default returns that default when it was omitted.
+with a default returns that default when it was omitted. Complete the program
+setup with `App.RegisterCommand(Cmd)`, where `App` is the `ICLIApplication`
+variable created with `CreateCLIApplication` as shown in [How-To](how-to.md).
 
 ## Use a validated value
 
 Values are currently exposed as strings, even after integer, float, Boolean,
-or enum validation. Convert them at the command boundary:
+or enum validation. Put conversion in the owning command's `Execute`. This
+replacement method for the `TOptionsCommand` pattern above needs `SysUtils`:
 
 ```pascal
+function TOptionsCommand.Execute: Integer;
 var
   RawCount: string;
   Count: Integer;
@@ -41,12 +75,13 @@ begin
   if GetParameterValue('--count', RawCount) and
      TryStrToInt(RawCount, Count) then
     WriteLn('Count: ', Count);
+  Result := 0;
 end;
 ```
 
-Use `TryStrToFloat` for a float and `SameText(RawValue, 'true')` for a Boolean.
-This string-based lookup is a current API boundary, not an indication that
-validation was skipped.
+Use `TryStrToFloat` for a float and `SameText(RawValue, 'true')` for an
+explicit Boolean. This string-based lookup is a current API boundary, not an
+indication that validation was skipped.
 
 ## Validation at a glance
 

--- a/docs/project.md
+++ b/docs/project.md
@@ -1,8 +1,8 @@
 # Contributing and support
 
 `cli-fp` is a small open-source framework maintained around a deliberately
-small public API. v1.4.0 is a documentation release: the supported runtime is
-still the class-based API described in these guides.
+small public API. v1.4.1 is a documentation-accuracy patch: the supported
+runtime is still the class-based API described in these guides.
 
 ## Supported environments
 

--- a/docs/technical-docs.md
+++ b/docs/technical-docs.md
@@ -8,6 +8,11 @@ completion generation, console behaviour, and tests. Application authors
 looking for public usage examples should start with the
 [first-CLI guide](getting-started.md).
 
+All Pascal blocks on this page are **source-context excerpts** from the unit
+named by their heading or surrounding text. They describe implementation and
+interfaces, not standalone application snippets; use the reader guides for a
+defined command class, command instance, and application setup.
+
 ## Architecture Overview
 
 The Free Pascal CLI Framework is built on a modular, interface-based architecture that promotes extensibility and maintainability. The framework is organized into several key components that work together to provide a complete CLI solution.

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -4,13 +4,19 @@
 [API reference](api-reference.md)
 
 Use `CLI.Console` for coloured output and `CLI.Progress` for a spinner or
-progress bar. These are normal Pascal calls; the framework does not decide
-what your command prints.
+progress bar. These calls normally live inside the `Execute` method of your
+`TBaseCommand` descendant; the framework does not decide what your command
+prints.
 
 ## Coloured output
 
+Import `CLI.Console` in the command unit and call the `TConsole` class
+directly—there is no console instance to declare. This is an **`Execute`-body
+fragment**:
+
 ```pascal
-uses CLI.Console;
+uses
+  CLI.Console;
 
 TConsole.WriteLn('Done', ccGreen);
 TConsole.WriteLn('Could not connect', ccRed);
@@ -22,37 +28,55 @@ for a runnable program.
 
 ## Spinner
 
-Use a spinner when the duration is unknown. Always stop it in `finally`:
+Use a spinner when the duration is unknown. This complete **`Execute`-method
+fragment** belongs to a declared `TDownloadCommand = class(TBaseCommand)`;
+its command unit needs `CLI.Interfaces` and `CLI.Progress`:
 
 ```pascal
-var Spinner: IProgressIndicator;
+function TDownloadCommand.Execute: Integer;
+var
+  Spinner: IProgressIndicator;
 begin
   Spinner := CreateSpinner(ssLine);
   Spinner.Start;
   try
     Spinner.Update(0, 'Downloading');
-    Download;
+    // Perform the download here.
   finally
     Spinner.Stop;
   end;
+  Result := 0;
 end;
 ```
 
+Always stop the indicator in `finally`.
+
 ## Progress bar
 
-Use a progress bar when you know the total work:
+Use a progress bar when you know the total work. This complete **`Execute`-
+method fragment** belongs to a declared `TBatchCommand = class(TBaseCommand)`;
+its command unit needs `SysUtils`, `CLI.Interfaces`, and `CLI.Progress`:
 
 ```pascal
-Bar := CreateProgressBar(Count);
-Bar.Start;
-try
-  for Index := 1 to Count do
-  begin
-    Process(Index);
-    Bar.Update(Index, Format('Processed %d of %d', [Index, Count]));
+function TBatchCommand.Execute: Integer;
+var
+  Bar: IProgressIndicator;
+  Index: Integer;
+  Total: Integer;
+begin
+  Total := 3;
+  Bar := CreateProgressBar(Total);
+  Bar.Start;
+  try
+    for Index := 1 to Total do
+    begin
+      // Process item Index here.
+      Bar.Update(Index, Format('Processed %d of %d', [Index, Total]));
+    end;
+  finally
+    Bar.Stop;
   end;
-finally
-  Bar.Stop;
+  Result := 0;
 end;
 ```
 
@@ -61,7 +85,7 @@ contains both patterns.
 
 ## Fail clearly
 
-Return a non-zero value from `Execute` for an expected command failure. Catch
-unexpected exceptions where your application can add useful context, then
-return `1`. The framework reports parse and validation errors before calling
-`Execute`.
+Return a non-zero value from your command's `Execute` for an expected command
+failure. Catch unexpected exceptions where your application can add useful
+context, then return `1`. The framework reports parse and validation errors
+before calling `Execute`.

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -1,6 +1,6 @@
 # cli-fp user manual
 
-This page remains as a stable starting point for existing links. The v1.4.0
+This page remains as a stable starting point for existing links. The v1.4.1
 documentation is organized by the job you want to do rather than as one long
 manual.
 

--- a/packages/lazarus/cli_fp.lpk
+++ b/packages/lazarus/cli_fp.lpk
@@ -36,7 +36,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. "/>
-    <Version Major="1" Minor="4" Release="0"/>
+    <Version Major="1" Minor="4" Release="1"/>
     <Files>
       <Item>
         <Filename Value="..\..\src\cli.application.pas"/>

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,62 +1,64 @@
-# Implementation Plan: cli-fp v1.4.0 documentation release
+# Implementation Plan: cli-fp v1.4.1 documentation accuracy patch
 
 ## Overview
 
-Turn the published documentation into a task-oriented learning path while
-keeping the current v1.3.3 runtime API intact. The release uses the existing
-canonical-example cleanup smoke test as the executable-documentation guard.
+Correct the published v1.4.0 documentation so readers always see the normal
+class-based cli-fp model: define a `TBaseCommand` descendant, create its
+instance, register options on that instance, and run its `Execute` method via
+an `ICLIApplication`. This is a documentation-only release; no runtime API,
+parser, or generator behaviour changes.
 
 ## Architecture Decisions
 
-- Keep `docs/user-manual.md` as a compact compatibility landing page rather
-  than breaking existing links; move reader-facing material into focused pages.
-- Add one concise task guide (`docs/how-to.md`) and link to deeper learning and
-  reference pages instead of duplicating explanations.
-- Keep generator safety and implementation details in technical documentation;
-  keep application-author guidance in `docs/codegen.md`.
-- Publish only current reader-facing pages through DocKit navigation; historical
-  release and completion test records remain unlisted.
-- Do not change the runtime API. Existing cleanup-smoke CI compiles every
-  canonical example and protects the beginner examples from documentation drift.
+- Treat the Getting Started QuickStart as the canonical full program; use
+  clearly labelled command patterns and in-context fragments elsewhere.
+- Give every reader-facing Pascal block either local declarations or an
+  explicit immediate context statement. Do not rely on implied `App`, `Root`,
+  `Command`, spinner, or progress variables.
+- Keep `docs/how-to.md` as one task-oriented page, but introduce the command
+  hierarchy there and link outward instead of duplicating full programs.
+- Keep technical documentation as source-context excerpts and label that scope
+  plainly rather than presenting implementation fragments as application code.
 
 ## Task List
 
-### Phase 1: Release foundation
+### Phase 1: Context audit and reader path
 
-- [ ] Task 1: Record the documentation audit and update release planning.
-- [ ] Task 2: Establish focused learning pages and compatibility links.
+- [ ] Task 1: Audit every published Pascal block and record its category
+  (complete program, command pattern, or explicitly scoped fragment).
+- [ ] Task 2: Add the command/object/application mental model to Getting
+  Started, Commands, and How-To; repair root, named, and nested command setup.
 
-### Checkpoint: Learning path
+### Checkpoint: Reader context
 
-- [ ] Documentation links resolve locally.
-- [ ] Root, named, and nested command shapes have distinct entry points.
+- [ ] A reader of How-To alone can identify the developer-defined
+  `TBaseCommand` descendant, the option-owning instance, and `Execute`.
+- [ ] No reader-facing Pascal block contains an unexplained identifier.
 
-### Phase 2: Task-oriented documentation
+### Phase 2: Recipe and reference accuracy
 
-- [ ] Task 3: Add concise How-To recipes grounded in tested APIs.
-- [ ] Task 4: Add limitations, terminal, and completion guidance.
-- [ ] Task 5: Refresh README, examples, generator, and API cross-links.
+- [ ] Task 3: Repair option, value-retrieval, exit-code, terminal, progress,
+  and debug recipes with exact units, receiver types, and scopes.
+- [ ] Task 4: Audit reference, technical, release, and navigation pages;
+  update v1.4.1 version records without changing runtime claims.
 
-### Checkpoint: Published documentation
+### Checkpoint: Documentation qualification
 
-- [ ] DocKit navigation contains each page once and excludes historical records.
-- [ ] Release notes, roadmap, and project material agree on v1.4.0.
+- [ ] DocKit check, strict audit, and build succeed.
+- [ ] Framework, generator, and canonical-example checks succeed as applicable.
 
-### Phase 3: Qualification
+### Phase 3: Review and release
 
-- [ ] Task 6: Run documentation checks, framework/generator checks, and example smoke checks.
-- [ ] Task 7: Review the final diff, commit, push, and create the requested PR/release if credentials permit.
-
-### Checkpoint: Complete
-
-- [ ] All release acceptance criteria that can be verified locally pass.
-- [ ] Working tree is clean after qualification.
+- [ ] Task 5: Review the diff for documentation/API accuracy, commit the
+  candidate, and publish the authorised PR.
+- [ ] Task 6: Qualify the exact candidate in CI, merge, tag v1.4.1, create the
+  GitHub release, and verify rendered Pages content.
 
 ## Risks and Mitigations
 
 | Risk | Impact | Mitigation |
 | --- | --- | --- |
-| Documentation claims drift from runtime behavior | High | Verify all recipe APIs against `src/` and existing FPCUnit tests. |
-| Breaking inbound manual links | Medium | Retain `user-manual.md` as a short migration/learning index. |
-| DocKit tooling unavailable locally | Medium | Run its configured commands if installed; otherwise validate JSON, Markdown links, and CI configuration locally and report the limitation. |
-| Remote permissions unavailable | Medium | Complete and qualify the candidate locally, then report exact remote steps blocked. |
+| A concise snippet still looks standalone | High | State its category and scope immediately before it; favour the canonical QuickStart link. |
+| Documentation drifts from source | High | Compare every touched API call to `src/` and compile all existing canonical examples. |
+| Docs-only changes do not trigger tests CI | Medium | Run local qualification and manually dispatch the existing Tests workflow for the PR branch. |
+| Pages deployment masks stale content | Medium | Verify route-specific rendered text after the main-branch deploy finishes. |

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,87 +1,53 @@
-# v1.4.0 documentation release tasks
+# v1.4.1 documentation accuracy tasks
 
-## Task 1: Audit and release plan
+## Task 1: Audit and classify published Pascal snippets
 
-**Description:** Capture the documentation problems found and move the planned
-release sequence to documentation-first v1.4.0.
+**Acceptance criteria:** Every Pascal block in a published page is classified
+as a complete program, complete command pattern, or explicitly scoped fragment;
+all identifiers have declarations or immediate context.
 
-**Acceptance criteria:**
-- [ ] Roadmap assigns documentation/developer learning to v1.4.0.
-- [ ] Runtime simplification work moves to v1.5.0 and application boundaries to v1.6.0.
-- [ ] Release records state that no runtime API is added.
-
-**Verification:** Read all changed release records and validate Markdown links.
+**Verification:** Search all published Markdown files and manually inspect each
+Pascal block against the source API.
 
 **Dependencies:** None
 
-**Files likely touched:** `ROADMAP.md`, `CHANGELOG.md`, `docs/project.md`
+## Task 2: Establish the class-based command model
 
-**Estimated scope:** Small: 1-2 files
-## Task 2: Focus the learning path
+**Acceptance criteria:** Getting Started, Commands, and How-To explicitly show
+`TBaseCommand` descendants, command instances, option registration, application
+registration, and `Execute`.
 
-**Description:** Replace the monolithic manual experience with focused pages,
-preserving the manual as a compatibility landing page.
-
-**Acceptance criteria:**
-- [ ] Newcomers have a first-CLI path.
-- [ ] Commands, options, terminal UX, completion, and limitations have clear homes.
-- [ ] Existing manual URLs continue to land on useful documentation.
-
-**Verification:** Validate internal links and compile the homepage example through the existing smoke suite.
+**Verification:** Apply the supplied reader test to How-To and compile the
+canonical QuickStart example.
 
 **Dependencies:** Task 1
 
-**Files likely touched:** `docs/*.md`, `docs/layout.json`
+## Task 3: Correct recipe and reference fragments
 
-**Estimated scope:** Medium: 3-5 files
+**Acceptance criteria:** Options, value retrieval, exit codes, terminal output,
+spinner/progress, debug casting, API reference, and technical excerpts state
+their receiver, units, and execution scope accurately.
 
-## Task 3: Add practical recipes
+**Verification:** Compare the touched APIs with `src/`; run DocKit checks.
 
-**Description:** Create a compact How-To guide answering common application-author questions with minimal, supported examples.
+**Dependencies:** Tasks 1-2
 
-**Acceptance criteria:**
-- [ ] Recipes cover command shape, parameters, values, output, completion, generator, debugging, and unsupported work.
-- [ ] Every API call matches the public source interface.
-- [ ] Deeper links avoid restating full tutorials.
+## Task 4: Release records and qualification
 
-**Verification:** Source/API comparison and Markdown link validation.
+**Acceptance criteria:** Version metadata, changelog, roadmap, project page,
+and v1.4.1 release notes truthfully describe a documentation-only patch; local
+documentation/framework/generator/example checks pass.
 
-**Dependencies:** Task 2
+**Verification:** Repository test scripts, DocKit strict audit/build, and diff
+whitespace check.
 
-**Files likely touched:** `docs/how-to.md`, `docs/commands.md`, `docs/options.md`
+**Dependencies:** Task 3
 
-**Estimated scope:** Medium: 3-5 files
+## Task 5: Review, publish, and verify release
 
-## Task 4: Publish-oriented refresh
+**Acceptance criteria:** The candidate is reviewed, approved by checks, merged,
+tagged, released, and its rendered docs demonstrate the repaired context.
 
-**Description:** Update the homepage, navigation, examples, generator guide, and reference links for the new information architecture.
+**Verification:** GitHub PR/checks/release state and route-specific Pages text.
 
-**Acceptance criteria:**
-- [ ] README stays concise and points to task-oriented documentation.
-- [ ] Navigation is intent-oriented with no duplicate entries.
-- [ ] Generator internals are separated from normal application guidance.
-
-**Verification:** DocKit check/build if available; otherwise JSON, link, and Markdown validation.
-
-**Dependencies:** Tasks 2-3
-
-**Files likely touched:** `README.md`, `docs/layout.json`, `docs/examples.md`, `docs/codegen.md`, `docs/api-reference.md`
-
-**Estimated scope:** Medium: 3-5 files
-
-## Task 5: Qualify and release
-
-**Description:** Run existing project checks, review the candidate, and perform authorized remote release operations if possible.
-
-**Acceptance criteria:**
-- [ ] Framework, generator, cleanup, documentation, and diff checks are recorded.
-- [ ] The candidate is committed and reviewed.
-- [ ] PR, CI, merge, tag, release, and Pages verification are completed or precisely reported as blocked.
-
-**Verification:** Repository scripts, DocKit tooling, GitHub CLI/API where authenticated.
-
-**Dependencies:** Tasks 1-4
-
-**Files likely touched:** release metadata and documentation only
-
-**Estimated scope:** Small: 1-2 files
+**Dependencies:** Task 4


### PR DESCRIPTION
## Summary\n- make the normal class descendant -> command instance -> application registration model explicit\n- repair published Pascal snippets with declared or explicit fragment context\n- release the documentation-only v1.4.1 patch\n\n## Qualification\n- dockit-fp check\n- dockit-fp audit --strict\n- dockit-fp build\n- framework tests (43 passed)\n- generator suite and compile smoke\n- eight-example cleanup smoke\n- compiled an integration program using the documented named/nested, terminal, progress, and DebugMode patterns\n\nNo runtime API, parser, or generator behavior changes.