### PR TITLE
Release cli-fp v1.5.0: defensive CLI core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-09-11
+
+### Added
+
+- Early validation for command names, parameter flags, duplicate definitions,
+  nil commands, and cyclic command trees.
+- Regression coverage for malformed definitions, parser edge cases, output
+  hardening, and generator metadata.
+
+### Changed
+
+- Unexpected positional arguments now fail with exit code `1`; the `--`
+  terminator remains intentionally unsupported.
+- Duplicate options retain explicit v1.x last-occurrence-wins behavior.
+- Option lookup and duplicate detection are consistently case-insensitive.
+- Date/time help and validation advertise the canonical `YYYY-MM-DD HH:MM`
+  format while retaining compatibility with values containing seconds.
+
+### Fixed
+
+- Missing parameter values now deterministically return `False` and an empty
+  output string.
+- Enum values containing spaces are parsed literally.
+- Empty flags are excluded from lookup and completion suggestions.
+- Progress widths are bounded, spinner updates no longer sleep, and coloured
+  output restores terminal state safely.
+
+### Security
+
+- Terminal ESC/NUL characters are sanitized from rendered output.
+- Bash/PowerShell completion metadata is quoted, and generated Pascal strings
+  safely encode apostrophes and control characters.
+- Generator JSON and manifest corruption now fails clearly without being
+  treated as empty configuration.
+
+### Documentation
+
+- Added beginner setup guidance for FPC, empty-folder use, `-Fu`, Lazarus,
+  ownership, root commands, PowerShell, and Linux casing.
+- Updated limitations, API, terminal, generator, roadmap, and versioned docs
+  metadata for v1.5.0.
+
 ## [1.4.3] - 2026-09-11
 
 ### Documentation / Maintenance
@@ -469,7 +511,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README with quick start guide
 - System requirements and compatibility information
 
-[Unreleased]: https://github.com/ikelaiah/cli-fp/compare/v1.4.2...HEAD
+[Unreleased]: https://github.com/ikelaiah/cli-fp/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/ikelaiah/cli-fp/compare/v1.4.3...v1.5.0
+[1.4.3]: https://github.com/ikelaiah/cli-fp/compare/v1.4.2...v1.4.3
 [1.4.2]: https://github.com/ikelaiah/cli-fp/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/ikelaiah/cli-fp/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/ikelaiah/cli-fp/compare/v1.3.3...v1.4.0

--- a/README.md
+++ b/README.md
@@ -7,13 +7,34 @@
 [![Lazarus](https://img.shields.io/badge/Lazarus-package-60A5FA.svg)](https://github.com/ikelaiah/cli-fp/blob/main/packages/lazarus/cli_fp.lpk)
 ![Supports Windows](https://img.shields.io/badge/support-Windows-F59E0B?logo=Windows)
 ![Supports Linux](https://img.shields.io/badge/support-Linux-F59E0B?logo=Linux)
-[![Version](https://img.shields.io/badge/version-1.4.3-8B5CF6.svg)](https://github.com/ikelaiah/cli-fp/blob/main/CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.5.0-8B5CF6.svg)](https://github.com/ikelaiah/cli-fp/blob/main/CHANGELOG.md)
 [![Documentation](https://img.shields.io/badge/Docs-Website-brightgreen.svg)](https://ikelaiah.github.io/cli-fp/)
 [![Tests](https://github.com/ikelaiah/cli-fp/actions/workflows/tests.yml/badge.svg)](https://github.com/ikelaiah/cli-fp/actions/workflows/tests.yml)
 
 `cli-fp` is a small Free Pascal framework for native command-line programs. It
 provides command trees, validated options, generated help and shell completion,
 colours, spinners, and progress bars—without third-party runtime dependencies.
+
+## Prerequisites
+
+- Install [Free Pascal](https://www.freepascal.org/download.html); FPC 3.2.2 is
+  the tested repository version. Check it with `fpc -iV`.
+- Put the `fpc` executable on your `PATH` so the compiler command works from a
+  terminal.
+- [Lazarus](https://www.lazarus-ide.org/) is optional. It can use the supplied
+  package at `packages/lazarus/cli_fp.lpk`.
+
+If you start in an empty folder, copy the QuickStartDemo source and compile it
+with a unit search path pointing at the cloned library:
+
+```bash
+fpc -Fu/path/to/cli-fp/src QuickStartDemo.lpr
+```
+
+`-Fu` means “add this directory to FPC's unit search path.” If compilation
+reports `Fatal: Can't find unit CLI.Interfaces`, the path is missing or points
+to the wrong checkout. In Lazarus, install/open `packages/lazarus/cli_fp.lpk`
+to provide the same unit path through the IDE.
 
 ## Your first CLI
 
@@ -71,6 +92,20 @@ Hello, Ada!
 On PowerShell, use `fpc "-Fu.\src" .\examples\QuickStartDemo\QuickStartDemo.lpr`
 and run `.\examples\QuickStartDemo\QuickStartDemo.exe --name Ada`.
 
+The empty name in `THelloCommand.Create('', ...)` marks the root/default
+command, so the invocation is `hello --name Ada`, not `hello greet --name Ada`.
+Keep the command and application references and let the `ICLIApplication` own
+the registered command tree; do not manually free registered commands.
+`Halt(App.Execute)` is the beginner-recommended program tail.
+
+Quick self-checks are:
+
+```text
+hello --help       # generated usage and --name
+hello --version    # hello version 1.0.0
+hello --name Ada   # Hello, Ada!
+```
+
 ## Choose a CLI shape
 
 | Shape | Invocation | Start with |
@@ -101,15 +136,13 @@ Use [`cli-fp-gen`](docs/codegen.md) when a larger command tree benefits from a
 scaffolded project layout. It is optional; the program above is the shortest
 way to start.
 
-## Requirements
+## Platform notes
 
-- Free Pascal 3.2.2 is the tested compiler version.
 - Windows and Linux run the repository's CI checks.
-- Lazarus is optional; a runtime package is available in the
-  [`packages/lazarus/`](https://github.com/ikelaiah/cli-fp/tree/main/packages/lazarus)
-  directory.
 - The runtime has no third-party dependencies. The generator uses FCL JSON
   units.
+- On Linux, filenames and unit names are case-sensitive; a casing mismatch
+  that Windows tolerates can prevent compilation.
 
 ## Contributing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -148,27 +148,29 @@ did not define.
 **Maintenance outcome:** developers can find the shortest correct path for a
 common task without guessing which manual or reference page contains it.
 
-## v1.5.0 — Make Simple CLIs Simple
+## v1.5.0 — Defensive CLI Core (completed 2026-09-11)
 
-- Introduce a single beginner-facing facade with a callback-based command API.
-- Add typed argument access for strings, integers, booleans, floats, and other
-  supported parameter types so command code does not parse validated strings a
-  second time.
-- Implement the simple API as a facade over the existing command machinery so
-  parsing and validation remain single-sourced.
-- Keep the class-based `TBaseCommand` API available for advanced applications.
-- Make the primary example a single source file that does not require the
-  project generator.
+- Validate command names, parameter flags, duplicate definitions, nil commands,
+  and command-tree cycles before dispatch or rendering.
+- Reject unsupported positional arguments clearly; preserve last-occurrence-wins
+  option semantics and deterministic global help handling.
+- Harden completion/Pascal output, terminal text, colour handling, progress
+  widths, and spinner update cadence.
+- Improve the beginner path with prerequisite, ownership, root-command, and
+  troubleshooting guidance while keeping the class-based public facade.
 
-**Maintenance outcome:** beginner-oriented ergonomics improve without creating
-a second framework to maintain.
+**Maintenance outcome:** valid v1.x CLIs remain familiar while malformed
+definitions and unsafe edge cases fail predictably.
 
 ## v1.6.0 — Finish the Application Core Boundaries
 
+- Continue internal architecture cleanup without changing the public facade.
 - Separate command selection and execution orchestration from parsing and
   validation.
 - Extract Bash and PowerShell script rendering from `TCLIApplication`, building
   on the completion engine introduced in v1.3.3.
+- Deduplicate command lookup, path-building, and output helpers.
+- Improve console/progress internals and test seams.
 - Strengthen the internal help and completion boundaries introduced in v1.3.3
   without exposing them as new public APIs.
 - Preserve existing observable behaviour with the v1.3.3 characterization
@@ -180,11 +182,15 @@ can be made and tested independently.
 
 ## v2.0.0 — Make Execution State Explicit
 
+- Evaluate actual positional-argument support and `--` terminator semantics
+  together as one parser design.
 - Adopt an explicit execution-context contract for commands.
 - Remove legacy shared-state plumbing between the application and commands.
 - Remove test-only methods and mutable implementation details from the public
   concrete application surface.
 - Remove APIs deprecated during the 1.x releases.
+- Reconsider the exception hierarchy and other breaking parser/API
+  simplifications.
 
 **Maintenance outcome:** command inputs and ownership are explicit, legacy
 compatibility paths are retired, and the core has one coherent execution

--- a/docs/RELEASE_NOTES_v1.5.0.md
+++ b/docs/RELEASE_NOTES_v1.5.0.md
@@ -1,0 +1,33 @@
+# cli-fp v1.5.0 — Defensive CLI Core
+
+Release date: 2026-09-11
+
+v1.5.0 keeps the familiar class-based `TBaseCommand` / `ICLIApplication`
+facade and makes invalid definitions and edge-case output safer.
+
+## Highlights
+
+- Invalid command names, flags, duplicates, nil commands, and cyclic command
+  trees fail early with actionable exceptions.
+- Unexpected positional arguments now produce an error and exit code `1`.
+  Duplicate options continue to use the last value supplied.
+- Parameter lookup is consistently case-insensitive, missing values clear the
+  output variable, and enum values may contain spaces.
+- Completion scripts, terminal text, and generated Pascal literals are safer
+  around shell-sensitive and control characters.
+- Colour disables itself for redirected output and `NO_COLOR`; progress widths
+  are capped at 200 characters; spinner updates do not block with a sleep.
+
+## Compatibility
+
+Root, named, and nested command programs remain supported. The empty command
+name still means the root/default action. Date/time help documents
+`YYYY-MM-DD HH:MM`; existing values with seconds remain accepted for v1.x
+compatibility.
+
+Positional-argument APIs, `--` terminator semantics, per-command versions, a
+major `TCLIApplication` split, and removal of deprecated/no-op APIs are
+deliberately deferred to later design work.
+
+See the [full changelog](../CHANGELOG.md) and the [current limitations](limitations.md)
+for details.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -85,6 +85,8 @@ and return `0` on success. Use an empty `AName` for a root command.
 
 `GetParameterValue` is protected, so call it from your descendant's `Execute`.
 It finds either registered flag spelling and returns values as strings.
+Lookup is case-insensitive; a missing value returns `False` and clears the
+output string.
 
 ### Register parameters
 
@@ -111,6 +113,9 @@ for validation behavior and [How do I...?](how-to.md) for minimal examples.
 
 `TParameterType` contains `ptString`, `ptInteger`, `ptFloat`, `ptBoolean`,
 `ptPath`, `ptEnum`, `ptDateTime`, `ptArray`, `ptPassword`, and `ptUrl`.
+
+The canonical date/time text is `YYYY-MM-DD HH:MM`; existing v1.x values with
+seconds remain accepted for compatibility.
 
 `ICommandParameter` exposes `ShortFlag`, `LongFlag`, `Description`, `Required`,
 `ParamType`, `DefaultValue`, and `AllowedValues`. For lower-level registration,
@@ -179,3 +184,9 @@ Applications receive `-h`/`--help`, `--help-complete`, and `-v`/`--version`.
 When it is the first argument, `--completion-file` prints a Bash script and
 `--completion-file-pwsh` prints a PowerShell script. See
 [shell completion](completion.md) for usage.
+
+Definitions are validated when commands are registered or parameters are
+added. Invalid names, flags, duplicate siblings/options, nil commands, and
+command-tree cycles raise developer-facing exceptions. The parser rejects
+unexpected positional arguments with exit code `1`; it does not implement the
+`--` terminator in v1.5.0.

--- a/docs/codegen.md
+++ b/docs/codegen.md
@@ -60,6 +60,17 @@ The generator creates command stubs once and preserves them on normal
 regeneration. Generated registry/program files are rewritten from
 `clifp.json`.
 
+Generator validation rejects malformed command and option tokens, including
+bare `-`/`--`, whitespace, dash-prefixed command names, and duplicate flags.
+`--description` consumes one command-line argument, so quote descriptions that
+contain spaces. Corrupt project JSON or generated manifests fail with an
+explicit error; they are never silently treated as empty configuration.
+
+Command descriptions are escaped as Pascal string expressions during
+generation, so apostrophes and control characters cannot produce invalid
+source. Generated files remain constrained to the project-owned paths listed
+by the manifest.
+
 ## Project specification
 
 `clifp.json` is the source of truth. Commands are a flat list; use a slash

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -3,7 +3,7 @@
 [Start here](getting-started.md) · [How do I...?](how-to.md) ·
 [Options](options.md) · [Limitations](limitations.md)
 
-In normal v1.4.x code, a command is an object you define by subclassing
+In normal v1.5.x code, a command is an object you define by subclassing
 `TBaseCommand`. The object owns its registered options; the application owns
 the command tree and calls the selected object's `Execute` method.
 
@@ -169,7 +169,8 @@ does not receive options from its children. For a runnable nested example, see
 command. `--version` is an application-level request when used as the first
 argument. Return `0` from a command's `Execute` for success and a non-zero
 integer for an application failure; the setup fragments use `Halt(App.Execute)`
-to forward that result to the shell.
+to forward that result to the shell. The application owns registered commands
+through its interfaces, so do not manually free them.
 
 See [How do I return a non-zero exit code?](how-to.md#how-do-i-return-a-non-zero-exit-code)
 for a focused method pattern.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,7 @@ complete program below is also the repository's
 [QuickStartDemo](https://github.com/ikelaiah/cli-fp/tree/main/examples/QuickStartDemo),
 which is compiled by the Windows and Linux example smoke checks.
 
-The program follows the normal v1.4.x ownership model: `THelloCommand`
+The program follows the normal v1.5.x ownership model: `THelloCommand`
 descends from `TBaseCommand`, `Main` is its instance and owns `--name`, and
 `App` is the `ICLIApplication` that parses the invocation and calls
 `Main.Execute`.
@@ -61,7 +61,19 @@ fpc "-Fu.\src" .\examples\QuickStartDemo\QuickStartDemo.lpr
 ```
 
 Both commands print `Hello, Ada!`. Run `--help` to see generated usage and
-the option description.
+the option description. `hello --version` prints `hello version 1.0.0`.
+
+`THelloCommand.Create('', ...)` uses an empty name intentionally: it represents
+the root/default command, so users run `hello --name Ada`, not
+`hello greet --name Ada`.
+
+The application owns the registered command tree through its interfaces. Do
+not manually free registered commands; the beginner-recommended program tail
+is `Halt(App.Execute)`.
+
+The `{$mode objfpc}{$H+}` directive selects Free Pascal's Object Pascal mode
+and long strings. If the compiler reports syntax or class/interface errors,
+check that the directive is present before the `uses` clause.
 
 ## What the program does
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -148,6 +148,11 @@ Greet.AddEnumParameter('-l', '--level', 'Log level',
   'debug|info|warn|error', False, 'info');
 ```
 
+Use `AddFlag` when presence alone enables a feature: `--verbose` becomes
+`true`, while omission returns `false`. Use `AddBooleanParameter` when callers
+must write an explicit value such as `--verbose true` or `--verbose false`.
+Option lookup is case-insensitive and repeated options use the last value.
+
 ### Path, URL, and password
 
 ```pascal
@@ -188,7 +193,8 @@ end;
 
 `GetParameterValue` is protected, so it belongs in the command class—not the
 program setup. Values remain strings after validation; use `TryStrToFloat` for
-a float. An absent `AddFlag` normally supplies `false`.
+a float. An absent `AddFlag` normally supplies `false`. `GetParameterValue`
+returns `False` and clears its output string when the option has no value.
 
 ## How do I return a non-zero exit code?
 
@@ -294,6 +300,11 @@ source ./myapp-completion.bash
 The request must be the first argument. See [shell completion](completion.md)
 for installation and behavior.
 
+On Windows, quote the unit path and descriptions with PowerShell's normal
+quoting rules, for example `fpc "-Fu.\src" .\src\Myapp.lpr`; do not paste Bash
+line-continuation or variable syntax into PowerShell. On Linux, filename and
+unit casing must match exactly.
+
 ## How do I generate PowerShell completion?
 
 ```powershell
@@ -341,7 +352,7 @@ place to expose password values.
 ## How do I do something cli-fp does not support?
 
 Read [current limitations](limitations.md) first. In particular, positional
-arguments, inherited global options, typed parameter access, and dynamic
+arguments, the `--` terminator, inherited global options, typed parameter access, and dynamic
 completion callbacks are not current features. Build a small application-level
 adapter if it fits your program, or open an issue with the command line and
 behavior you need. Planned roadmap work is not a released contract.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -2,13 +2,15 @@
 
 [How do I...?](how-to.md) · [Commands](commands.md) · [Options](options.md)
 
-These are current v1.4.2 boundaries verified against the public source and
+These are current v1.5.0 boundaries verified against the public source and
 tests. They are intentionally easy to find so a limitation does not look like
 an undocumented feature.
 
 ## Command model
 
 - Positional arguments are not supported.
+- The `--` option terminator is not supported because positional arguments are
+  not supported yet.
 - Root-command options belong only to the root action. Named commands and
   subcommands do not inherit them.
 - The framework has no persistent/global option model across a command tree.
@@ -31,7 +33,8 @@ an undocumented feature.
 - Registered integer and float options accept negative values in either
   `--count=-1` or `--count -1` form. For another value beginning with `-`, use
   the equals form so it is not read as a new option.
-- Option flags are case-sensitive; use the spelling registered by the command.
+- Option flags are matched case-insensitively. If an option appears more than
+  once, the last occurrence wins.
 
 ## Completion
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -60,6 +60,11 @@ with a default returns that default when it was omitted. Complete the program
 setup with `App.RegisterCommand(Cmd)`, where `App` is the `ICLIApplication`
 variable created with `CreateCLIApplication` as shown in [How-To](how-to.md).
 
+`AddFlag` is a presence flag: it is `false` when omitted and becomes `true`
+when present. `AddBooleanParameter` expects an explicit `true` or `false`
+value, such as `--color true`. Flag matching is case-insensitive, and when an
+option is supplied more than once, the last occurrence wins.
+
 ## Use a validated value
 
 Values are currently exposed as strings, even after integer, float, Boolean,
@@ -92,6 +97,8 @@ indication that validation was skipped.
 - URLs must start with `http://`, `https://`, `git://`, or `ssh://`.
 - Paths and passwords are accepted as strings; a path is not checked for
   existence and a password is not encrypted.
+- Date/time values use the documented `YYYY-MM-DD HH:MM` representation. The
+  parser remains compatible with existing v1.x values that include seconds.
 
 For syntax rules and surprising boundaries, read [Limitations and gotchas](limitations.md).
 For every public signature, use the [API reference](api-reference.md).

--- a/docs/project.md
+++ b/docs/project.md
@@ -1,7 +1,7 @@
 # Contributing and support
 
 `cli-fp` is a small open-source framework maintained around a deliberately
-small public API. v1.4.2 is a correctness and maintenance patch: the supported
+small public API. v1.5.0 is a defensive correctness release: the supported
 runtime remains the class-based API described in these guides.
 
 ## Supported environments

--- a/docs/technical-docs.md
+++ b/docs/technical-docs.md
@@ -566,15 +566,14 @@ The framework implements parameter validation in `TCLIApplication.ValidateParame
   TryStrToDateTime(Value, DateTimeValue, LocalFormatSettings);
   ```
   This does not change process-wide `FormatSettings`.
-  `YYYY-MM-DD HH:MM` is the recommended portable representation, but
-  `TryStrToDateTime` currently also accepts some date-only values and values
-  containing seconds. `AddDateTimeParameter` still labels generated help with
-  `HH:MM:SS`; this is an implementation inconsistency rather than strict
-  validation.
+  `YYYY-MM-DD HH:MM` is the documented portable representation. The parser
+  remains compatible with existing v1.x values containing seconds, but help
+  and validation errors consistently advertise the canonical format.
   
 - `ptEnum`: Validates against pipe-separated allowed values:
   ```pascal
   AllowedValues.Delimiter := '|';
+  AllowedValues.StrictDelimiter := True;
   AllowedValues.DelimitedText := Param.AllowedValues;
   ```
 

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -8,6 +8,11 @@ progress bar. These calls normally live inside the `Execute` method of your
 `TBaseCommand` descendant; the framework does not decide what your command
 prints.
 
+Colour is disabled when stdout is redirected or when the `NO_COLOR` environment
+variable is set. Terminal text removes NUL and ESC control characters while
+preserving ordinary prose, Unicode, and line breaks. Coloured writes restore
+the previous terminal state even if the underlying output raises an error.
+
 ## Coloured output
 
 Import `CLI.Console` in the command unit and call the `TConsole` class
@@ -51,6 +56,9 @@ end;
 
 Always stop the indicator in `finally`.
 
+`Update` renders immediately; it does not sleep. Choose the refresh cadence in
+the work loop that calls it.
+
 ## Progress bar
 
 Use a progress bar when you know the total work. This complete **`Execute`-
@@ -82,6 +90,11 @@ end;
 
 The [ProgressDemo](https://github.com/ikelaiah/cli-fp/tree/main/examples/ProgressDemo)
 contains both patterns.
+
+Progress bars cap their configured visual width at 200 characters, so a bad
+configuration cannot request an enormous allocation. `ClearLine` uses ANSI
+line clearing on a capable terminal and falls back to a bounded portable
+overwrite otherwise.
 
 ## Fail clearly
 

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -1,6 +1,6 @@
 # cli-fp user manual
 
-This page remains as a stable starting point for existing links. The v1.4.2
+This page remains as a stable starting point for existing links. The v1.5.0
 documentation is organized by the job you want to do rather than as one long
 manual.
 

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,7 +1,8 @@
 {
   "schema_version": 1,
-  "current": "1.4.3",
+  "current": "1.5.0",
   "versions": [
+    {"release": "1.5.0", "source_ref": "v1.5.0"},
     {"release": "1.4.3", "source_ref": "v1.4.3"},
     {"release": "1.4.2", "source_ref": "v1.4.2"},
     {"release": "1.4.1", "source_ref": "v1.4.1"},

--- a/examples/LongRunningOpDemo/LongRunningOpDemo.lpr
+++ b/examples/LongRunningOpDemo/LongRunningOpDemo.lpr
@@ -110,7 +110,7 @@ type
         except
           on E: Exception do
           begin
-            TConsole.WriteLn('Error: Invalid date/time format. Use YYYY-MM-DD HH:MM:SS', ccRed);
+            TConsole.WriteLn('Error: Invalid date/time format. Use YYYY-MM-DD HH:MM', ccRed);
             Exit(1);
           end;
         end;

--- a/examples/ProgressDemo/ProgressDemo.lpr
+++ b/examples/ProgressDemo/ProgressDemo.lpr
@@ -114,8 +114,6 @@ begin
 
     // Register command with application
     App.RegisterCommand(Cmd);
-    Cmd := nil;  // Clear reference as App now owns the command
-
     // Execute the application and get exit code
     ExitCode := App.Execute;
   except

--- a/examples/SimpleDemo/SimpleDemo.lpr
+++ b/examples/SimpleDemo/SimpleDemo.lpr
@@ -103,8 +103,6 @@ begin
     { Register the command with the application
       This makes it available for use }
     App.RegisterCommand(Cmd);
-    Cmd := nil;  // App takes ownership, clear our reference
-
     { Execute the application and store exit code
       This processes command line and runs the appropriate command }
     ExitCode := App.Execute;

--- a/examples/SubCommandDemo/SubCommandDemo.lpr
+++ b/examples/SubCommandDemo/SubCommandDemo.lpr
@@ -254,14 +254,6 @@ begin
     RemoteRemoveCmd.AddStringParameter('-n', '--name', 'Remote name', True);
     RemoteCmd.AddSubCommand(RemoteRemoveCmd);
 
-    // Clean up command references (not strictly necessary but good practice)
-    RepoCmd := nil;
-    InitCmd := nil;
-    CloneCmd := nil;
-    RemoteCmd := nil;
-    RemoteAddCmd := nil;
-    RemoteRemoveCmd := nil;
-
     // Execute the application and get exit code
     ExitCode := App.Execute;
   except

--- a/packages/lazarus/cli_fp.lpk
+++ b/packages/lazarus/cli_fp.lpk
@@ -36,7 +36,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. "/>
-    <Version Major="1" Minor="4" Release="3"/>
+    <Version Major="1" Minor="5" Release="0"/>
     <Files>
       <Item>
         <Filename Value="..\..\src\cli.application.pas"/>

--- a/src/cli.application.pas
+++ b/src/cli.application.pas
@@ -67,7 +67,7 @@ type
 
     { Parses command-line arguments into FParsedParams
       Handles both --param=value and -p value formats }
-    procedure ParseCommandLine;
+    function ParseCommandLine: Boolean;
 
     { Loads the process command line into FArguments. }
     procedure LoadProcessArguments;
@@ -237,7 +237,7 @@ implementation
 
 uses
   StrUtils, CLI.Internal.ParameterValues, CLI.Internal.Help,
-  CLI.Internal.Completion;
+  CLI.Internal.Completion, CLI.Internal.Text, CLI.Validation;
 
 { Constructor: Initializes a new CLI application instance
   @param AName The name of the application
@@ -250,9 +250,11 @@ begin
   FName := AName;
   FVersion := AVersion;
   FRootCommand := ARootCommand;
+  if Assigned(FRootCommand) then
+    ValidateCommandTree(FRootCommand, 'Root command', True);
   FCommands := TCommandList.Create;
   FParsedParams := TStringList.Create;
-  FParsedParams.CaseSensitive := True;  // Parameters are case-sensitive
+  FParsedParams.CaseSensitive := False; // Parameter lookup is case-insensitive
   FParamStartIndex := 2;                // Skip program name and command name
   FDebugMode := False;                  // Debug output disabled by default
   {$IFDEF CLI_FP_TESTING}
@@ -268,11 +270,11 @@ begin
   {$IFDEF CLI_FP_TESTING}
   if Assigned(FOutputCapture) then
   begin
-    FOutputCapture.Add(Text);
+    FOutputCapture.Add(SanitizeTerminalText(Text));
     Exit;
   end;
   {$ENDIF}
-  TConsole.WriteLn(Text);
+  TConsole.WriteLn(SanitizeTerminalText(Text));
 end;
 
 procedure TCLIApplication.WriteOutput(const Text: string;
@@ -281,11 +283,11 @@ begin
   {$IFDEF CLI_FP_TESTING}
   if Assigned(FOutputCapture) then
   begin
-    FOutputCapture.Add(Text);
+    FOutputCapture.Add(SanitizeTerminalText(Text));
     Exit;
   end;
   {$ENDIF}
-  TConsole.WriteLn(Text, Color);
+  TConsole.WriteLn(SanitizeTerminalText(Text), Color);
 end;
 
 procedure TCLIApplication.WriteHelpLine(const Text: string;
@@ -328,10 +330,13 @@ procedure TCLIApplication.RegisterCommand(const Command: ICommand);
 var
   i: Integer;
 begin
+  if not Assigned(Command) then
+    raise EArgumentNilException.Create('Registered command cannot be nil');
+  ValidateCommandTree(Command, 'Registered command');
   // Check for duplicate command names
   for i := 0 to FCommands.Count - 1 do
     if SameText(FCommands[i].Name, Command.Name) then
-      raise Exception.CreateFmt('Command "%s" is already registered', [Command.Name]);
+      raise EArgumentException.CreateFmt('Command "%s" is already registered', [Command.Name]);
 
   FCommands.Add(Command);
 end;
@@ -375,20 +380,20 @@ begin
     Exit;
   end;
 
-  if (ArgumentCount = 1) and
+  if (ArgumentCount >= 1) and
     ((ArgumentAt(1) = '-h') or (ArgumentAt(1) = '--help')) then
   begin
     ShowHelp;
     Exit;
   end;
 
-  if (ArgumentCount = 1) and (ArgumentAt(1) = '--help-complete') then
+  if (ArgumentCount >= 1) and (ArgumentAt(1) = '--help-complete') then
   begin
     ShowCompleteHelp;
     Exit;
   end;
 
-  if (ArgumentCount = 1) and
+  if (ArgumentCount >= 1) and
     ((ArgumentAt(1) = '-v') or (ArgumentAt(1) = '--version')) then
   begin
     ShowVersion;
@@ -459,6 +464,12 @@ begin
   while (i <= ArgumentCount) and not StartsStr('-', ArgumentAt(i)) do
   begin
     SubCmdName := ArgumentAt(i);
+    if Length(CurrentCmd.SubCommands) = 0 then
+    begin
+      TConsole.WriteLn('Error: Unexpected positional argument "' +
+        SubCmdName + '"', ccRed);
+      Exit;
+    end;
     SubCmd := nil;
     for Cmd in CurrentCmd.SubCommands do
       if SameText(Cmd.Name, SubCmdName) then
@@ -546,7 +557,8 @@ function TCLIApplication.ExecuteCurrentCommand: Integer;
 var
   ParameterReceiver: ICommandParameterReceiver;
 begin
-  ParseCommandLine;
+  if not ParseCommandLine then
+    Exit(1);
 
   if Supports(FCurrentCommand, ICommandParameterReceiver, ParameterReceiver) then
     ParameterReceiver.SetParsedParams(FParsedParams);
@@ -572,11 +584,12 @@ end;
   - Short format (-p value)
   - Boolean flags (--flag)
   Note: Updates FParsedParams with parsed values }
-procedure TCLIApplication.ParseCommandLine;
+function TCLIApplication.ParseCommandLine: Boolean;
 var
   i: Integer;
   Param, Value: string;
 begin
+  Result := True;
   FParsedParams.Clear;
   i := FParamStartIndex; // Start after program name and command name(s)
 
@@ -589,6 +602,12 @@ begin
     if FDebugMode then
       WriteOutput('Processing argument ' + IntToStr(i) + ': ' +
         RedactArgument(FCurrentCommand, Param), ccCyan);
+
+    if not StartsStr('-', Param) then
+    begin
+      TConsole.WriteLn('Error: Unexpected positional argument "' + Param + '"', ccRed);
+      Exit(False);
+    end;
 
     // Handle --param=value format
     if StartsStr('--', Param) then
@@ -692,13 +711,15 @@ var
   Param: ICommandParameter;
 begin
   Result := TStringList.Create;
-  Result.CaseSensitive := True;
+  Result.CaseSensitive := False;
   
   // Add command-specific parameter flags
   for Param in FCurrentCommand.Parameters do
   begin
-    Result.Add(Param.LongFlag);
-    Result.Add(Param.ShortFlag);
+    if Param.LongFlag <> '' then
+      Result.Add(Param.LongFlag);
+    if Param.ShortFlag <> '' then
+      Result.Add(Param.ShortFlag);
   end;
   
   // Add global flags
@@ -770,6 +791,7 @@ end;
 function TCLIApplication.GetParameterValue(const Param: ICommandParameter; 
   out Value: string): Boolean;
 begin
+  Value := '';
   Result := TryGetParameterValue(Param, FParsedParams, Value);
 end;
 
@@ -961,6 +983,7 @@ begin
         AllowedValues := TStringList.Create;
         try
           AllowedValues.Delimiter := '|';
+          AllowedValues.StrictDelimiter := True;
           AllowedValues.DelimitedText := Param.AllowedValues;
           
           Result := False;
@@ -1138,8 +1161,10 @@ procedure TCLIApplication.OutputBashCompletionScript;
       ParamFlags := ParamFlags + ' ';
     ParamFlags := ParamFlags + '--help -h';
     // Output Bash associative arrays for this path (no leading spaces)
-    TConsole.WriteLn('tree["' + Path + '|subcommands"]="' + SubNames + '"');
-    TConsole.WriteLn('tree["' + Path + '|params"]="' + ParamFlags + '"');
+    TConsole.WriteLn('tree[' + QuoteForBash(Path + '|subcommands') + ']=' +
+      QuoteForBash(SubNames));
+    TConsole.WriteLn('tree[' + QuoteForBash(Path + '|params') + ']=' +
+      QuoteForBash(ParamFlags));
     // Recurse for subcommands
     for Sub in Cmd.SubCommands do
       OutputBashTree(Sub, Path + ' ' + Sub.Name);
@@ -1181,8 +1206,10 @@ begin
   RootParamFlags := RootParamFlags +
     '--help --help-complete --version --completion-file --completion-file-pwsh -h -v';
   // Use a special root key for Bash associative array (no leading spaces)
-  TConsole.WriteLn('tree["__root__|subcommands"]="' + RootSubNames + '"');
-  TConsole.WriteLn('tree["__root__|params"]="' + RootParamFlags + '"');
+  TConsole.WriteLn('tree[' + QuoteForBash('__root__|subcommands') + ']=' +
+    QuoteForBash(RootSubNames));
+  TConsole.WriteLn('tree[' + QuoteForBash('__root__|params') + ']=' +
+    QuoteForBash(RootParamFlags));
 
   // Output the command tree
   for Cmd in FCommands do

--- a/src/cli.command.pas
+++ b/src/cli.command.pas
@@ -150,7 +150,7 @@ type
       @param LongFlag Long form flag (e.g., '--date')
       @param Description Parameter description
       @param Required Whether parameter is required
-      @param DefaultValue Default value if not provided (format: YYYY-MM-DD HH:MM:SS) }
+      @param DefaultValue Default value if not provided (format: YYYY-MM-DD HH:MM) }
     procedure AddDateTimeParameter(const ShortFlag, LongFlag, Description: string;
       Required: Boolean = False; const DefaultValue: string = '');
     
@@ -211,7 +211,7 @@ type
 implementation
 
 uses
-  CLI.Internal.ParameterValues, CLI.Internal.Help;
+  CLI.Internal.ParameterValues, CLI.Internal.Help, CLI.Validation;
 
 { Constructor: Creates new command instance
   @param AName Command name as used in CLI
@@ -271,7 +271,19 @@ end;
 { AddParameter: Adds a parameter to the command
   @param Parameter The parameter to add }
 procedure TBaseCommand.AddParameter(const Parameter: ICommandParameter);
+var
+  Existing: ICommandParameter;
 begin
+  ValidateParameterDefinition(Parameter, 'Command');
+  for Existing in FParameters do
+  begin
+    if (Parameter.LongFlag <> '') and SameText(Existing.LongFlag, Parameter.LongFlag) then
+      raise EArgumentException.CreateFmt(
+        'Command parameter long flag "%s" is already defined', [Parameter.LongFlag]);
+    if (Parameter.ShortFlag <> '') and SameText(Existing.ShortFlag, Parameter.ShortFlag) then
+      raise EArgumentException.CreateFmt(
+        'Command parameter short flag "%s" is already defined', [Parameter.ShortFlag]);
+  end;
   SetLength(FParameters, Length(FParameters) + 1);
   FParameters[High(FParameters)] := Parameter;
 end;
@@ -351,7 +363,7 @@ end;
 procedure TBaseCommand.AddDateTimeParameter(const ShortFlag, LongFlag, Description: string;
   Required: Boolean = False; const DefaultValue: string = '');
 begin
-  AddParameter(ShortFlag, LongFlag, Description + ' (format: YYYY-MM-DD HH:MM:SS)', Required, ptDateTime, DefaultValue);
+  AddParameter(ShortFlag, LongFlag, Description + ' (format: YYYY-MM-DD HH:MM)', Required, ptDateTime, DefaultValue);
 end;
 
 { AddArrayParameter: Helper to add an array parameter }
@@ -378,7 +390,22 @@ end;
 { AddSubCommand: Adds a subcommand to this command
   @param Command The subcommand to add }
 procedure TBaseCommand.AddSubCommand(const Command: ICommand);
+var
+  Existing: ICommand;
 begin
+  if not Assigned(Command) then
+    raise EArgumentNilException.Create('Subcommand cannot be nil');
+  ValidateCommandName(Command.Name, 'Subcommand');
+  ValidateCommandTree(Command, 'Subcommand');
+  if CommandTreeContainsName(Command, Name) then
+    raise EArgumentException.CreateFmt(
+      'Cannot add command "%s" as a child of "%s": command tree cycle detected',
+      [Command.Name, Name]);
+  for Existing in FSubCommands do
+    if SameText(Existing.Name, Command.Name) then
+      raise EArgumentException.CreateFmt(
+        'Subcommand "%s" is already defined under "%s"',
+        [Command.Name, Name]);
   SetLength(FSubCommands, Length(FSubCommands) + 1);
   FSubCommands[High(FSubCommands)] := Command;
 end;

--- a/src/cli.console.pas
+++ b/src/cli.console.pas
@@ -354,7 +354,7 @@ begin
   Result := (Handle <> INVALID_HANDLE_VALUE) and
     (GetConsoleMode(Handle, Mode));
 {$ELSE}
-  Result := fpIsATTY(1) = 1;
+  Result := isatty(1) = 1;
 {$ENDIF}
 end;
 

--- a/src/cli.console.pas
+++ b/src/cli.console.pas
@@ -34,6 +34,7 @@ type
       Called automatically in initialization section
       Platform-specific: Stores initial attributes on Windows }
     class procedure InitConsole;
+    class function ColorsEnabled: Boolean;
   public
     { Sets text foreground color
       @param Color The color to set for subsequent text output }
@@ -97,6 +98,8 @@ type
 implementation
 
 uses
+  SysUtils,
+  CLI.Internal.Text,
 {$IFDEF WINDOWS}
   Windows;
 {$ELSE}
@@ -135,11 +138,15 @@ var
   Handle: THandle;
   Info: TConsoleScreenBufferInfo;
 begin
+  if not ColorsEnabled then
+    Exit;
   Handle := GetStdHandle(STD_OUTPUT_HANDLE);
   GetConsoleScreenBufferInfo(Handle, Info);
   SetConsoleTextAttribute(Handle, (Info.wAttributes and $F0) or Ord(Color));
 {$ELSE}
 begin
+  if not ColorsEnabled then
+    Exit;
   case Color of
     ccBlack: System.Write(#27'[30m');
     ccBlue: System.Write(#27'[34m');
@@ -172,11 +179,15 @@ var
   Handle: THandle;
   Info: TConsoleScreenBufferInfo;
 begin
+  if not ColorsEnabled then
+    Exit;
   Handle := GetStdHandle(STD_OUTPUT_HANDLE);
   GetConsoleScreenBufferInfo(Handle, Info);
   SetConsoleTextAttribute(Handle, (Info.wAttributes and $0F) or (Ord(Color) shl 4));
 {$ELSE}
 begin
+  if not ColorsEnabled then
+    Exit;
   case Color of
     ccBlack: System.Write(#27'[40m');
     ccBlue: System.Write(#27'[44m');
@@ -207,10 +218,14 @@ class procedure TConsole.ResetColors;
 var
   Handle: THandle;
 begin
+  if not ColorsEnabled then
+    Exit;
   Handle := GetStdHandle(STD_OUTPUT_HANDLE);
   SetConsoleTextAttribute(Handle, FDefaultAttr);
 {$ELSE}
 begin
+  if not ColorsEnabled then
+    Exit;
   System.Write(#27'[0m');
 {$ENDIF}
 end;
@@ -219,15 +234,22 @@ end;
   Uses carriage return and spaces for universal compatibility }
 class procedure TConsole.ClearLine;
 begin
-  System.Write(#13);  // Carriage return
-  System.Write('                                                  ');  // Clear line
-  System.Write(#13);  // Return to start
+  if ColorsEnabled then
+    System.Write(#27'[2K'#13)
+  else
+  begin
+    System.Write(#13);
+    System.Write('                                                  ');
+    System.Write(#13);
+  end;
 end;
 
 { MoveCursorUp: Moves cursor up specified lines
   @param Lines Number of lines to move up }
 class procedure TConsole.MoveCursorUp(const Lines: Integer);
 begin
+  if not ColorsEnabled then
+    Exit;
   System.Write(#27'[', Lines, 'A');
 end;
 
@@ -235,6 +257,8 @@ end;
   @param Lines Number of lines to move down }
 class procedure TConsole.MoveCursorDown(const Lines: Integer);
 begin
+  if not ColorsEnabled then
+    Exit;
   System.Write(#27'[', Lines, 'B');
 end;
 
@@ -242,6 +266,8 @@ end;
   @param Columns Number of columns to move left }
 class procedure TConsole.MoveCursorLeft(const Columns: Integer);
 begin
+  if not ColorsEnabled then
+    Exit;
   System.Write(#27'[', Columns, 'D');
 end;
 
@@ -249,6 +275,8 @@ end;
   @param Columns Number of columns to move right }
 class procedure TConsole.MoveCursorRight(const Columns: Integer);
 begin
+  if not ColorsEnabled then
+    Exit;
   System.Write(#27'[', Columns, 'C');
 end;
 
@@ -256,6 +284,8 @@ end;
   Uses ANSI sequence that works on most terminals }
 class procedure TConsole.SaveCursorPosition;
 begin
+  if not ColorsEnabled then
+    Exit;
   System.Write(#27'7');
 end;
 
@@ -263,6 +293,8 @@ end;
   Uses ANSI sequence that works on most terminals }
 class procedure TConsole.RestoreCursorPosition;
 begin
+  if not ColorsEnabled then
+    Exit;
   System.Write(#27'8');
 end;
 
@@ -270,7 +302,7 @@ end;
   @param Text The text to write }
 class procedure TConsole.Write(const Text: string);
 begin
-  System.Write(Text);
+  System.Write(SanitizeTerminalText(Text));
 end;
 
 { Write: Outputs colored text without line ending
@@ -280,15 +312,18 @@ end;
 class procedure TConsole.Write(const Text: string; const FgColor: TConsoleColor);
 begin
   SetForegroundColor(FgColor);
-  System.Write(Text);
-  ResetColors;
+  try
+    System.Write(SanitizeTerminalText(Text));
+  finally
+    ResetColors;
+  end;
 end;
 
 { WriteLn: Outputs text with line ending
   @param Text The text to write }
 class procedure TConsole.WriteLn(const Text: string);
 begin
-  System.WriteLn(Text);
+  System.WriteLn(SanitizeTerminalText(Text));
 end;
 
 { WriteLn: Outputs colored text with line ending
@@ -298,8 +333,29 @@ end;
 class procedure TConsole.WriteLn(const Text: string; const FgColor: TConsoleColor);
 begin
   SetForegroundColor(FgColor);
-  System.WriteLn(Text);
-  ResetColors;
+  try
+    System.WriteLn(SanitizeTerminalText(Text));
+  finally
+    ResetColors;
+  end;
+end;
+
+class function TConsole.ColorsEnabled: Boolean;
+{$IFDEF WINDOWS}
+var
+  Handle: THandle;
+  Mode: DWORD;
+{$ENDIF}
+begin
+  if SysUtils.GetEnvironmentVariable('NO_COLOR') <> '' then
+    Exit(False);
+{$IFDEF WINDOWS}
+  Handle := GetStdHandle(STD_OUTPUT_HANDLE);
+  Result := (Handle <> INVALID_HANDLE_VALUE) and
+    (GetConsoleMode(Handle, Mode));
+{$ELSE}
+  Result := fpIsATTY(1) = 1;
+{$ENDIF}
 end;
 
 initialization

--- a/src/cli.internal.help.pas
+++ b/src/cli.internal.help.pas
@@ -76,6 +76,7 @@ procedure TCLIHelpRenderer.WriteParameters(
 var
   Param: ICommandParameter;
   RequiredText: string;
+  FlagText: string;
 begin
   for Param in Parameters do
   begin
@@ -83,8 +84,13 @@ begin
       RequiredText := ' (required)'
     else
       RequiredText := '';
-    WriteLine(Indent + Param.ShortFlag + ', ' +
-      PadRight(Param.LongFlag, 20) + Param.Description + RequiredText);
+    if (Param.ShortFlag <> '') and (Param.LongFlag <> '') then
+      FlagText := Param.ShortFlag + ', ' + Param.LongFlag
+    else if Param.LongFlag <> '' then
+      FlagText := Param.LongFlag
+    else
+      FlagText := Param.ShortFlag;
+    WriteLine(Indent + PadRight(FlagText, 20) + Param.Description + RequiredText);
     if Param.DefaultValue <> '' then
       WriteLine(Indent + '    Default: ' + Param.DefaultValue);
   end;

--- a/src/cli.internal.parametervalues.pas
+++ b/src/cli.internal.parametervalues.pas
@@ -37,8 +37,8 @@ function TryGetParameterValue(const Param: ICommandParameter;
 var
   Index: Integer;
 begin
-  Result := False;
   Value := '';
+  Result := False;
   if not Assigned(Param) or not Assigned(ParsedParams) then
     Exit;
 

--- a/src/cli.internal.text.pas
+++ b/src/cli.internal.text.pas
@@ -1,0 +1,21 @@
+unit CLI.Internal.Text;
+
+{$mode objfpc}{$H+}{$J-}
+
+interface
+
+function SanitizeTerminalText(const Text: string): string;
+
+implementation
+
+function SanitizeTerminalText(const Text: string): string;
+var
+  i: Integer;
+begin
+  Result := Text;
+  for i := Length(Result) downto 1 do
+    if (Result[i] = #0) or (Result[i] = #27) then
+      Delete(Result, i, 1);
+end;
+
+end.

--- a/src/cli.progress.pas
+++ b/src/cli.progress.pas
@@ -15,6 +15,9 @@ interface
 uses
   Classes, SysUtils, CLI.Interfaces, CLI.Console;
 
+const
+  MaxProgressBarWidth = 200;
+
 type
   { Spinner styles }
   TSpinnerStyle = (
@@ -204,7 +207,6 @@ begin
   DisplayText := ComposeText(FFrames[FFrame], ACaption);
   RenderText(DisplayText);
   FFrame := (FFrame + 1) mod Length(FFrames);  // Move to next frame
-  Sleep(100);  // Delay for animation
 end;
 
 { TProgressBar }
@@ -214,6 +216,10 @@ begin
   inherited Create;
   FTotal := ATotal;
   FWidth := AWidth;
+  if FWidth < 0 then
+    FWidth := 0
+  else if FWidth > MaxProgressBarWidth then
+    FWidth := MaxProgressBarWidth;
   FLastProgress := -1;  // Initialize to invalid progress to force first update
   FLastCaption := EmptyStr;
 end;
@@ -246,8 +252,6 @@ begin
   
   // Calculate filled portion of bar
   EffectiveWidth := FWidth;
-  if EffectiveWidth < 0 then
-    EffectiveWidth := 0;
   FilledWidth := Round((Percentage / 100) * EffectiveWidth);
   
   // Create progress bar text: [====    ] XX%

--- a/src/cli.validation.pas
+++ b/src/cli.validation.pas
@@ -1,0 +1,159 @@
+unit CLI.Validation;
+
+{$mode objfpc}{$H+}{$J-}
+
+interface
+
+uses
+  Classes, SysUtils, CLI.Interfaces;
+
+procedure ValidateCommandName(const Name, Context: string;
+  const AllowEmpty: Boolean = False);
+procedure ValidateParameterDefinition(const Parameter: ICommandParameter;
+  const Context: string);
+procedure ValidateCommandTree(const Command: ICommand;
+  const Context: string; const AllowEmptyRoot: Boolean = False);
+function CommandTreeContainsName(const Root: ICommand;
+  const TargetName: string): Boolean;
+
+implementation
+
+function IsAsciiAlphaNumeric(const Character: Char): Boolean;
+begin
+  Result := Character in ['A'..'Z', 'a'..'z', '0'..'9'];
+end;
+
+function IsValidLongFlag(const Flag: string): Boolean;
+var
+  i: Integer;
+begin
+  Result := (Length(Flag) >= 3) and (Copy(Flag, 1, 2) = '--') and
+    IsAsciiAlphaNumeric(Flag[3]);
+  if not Result then
+    Exit;
+  for i := 3 to Length(Flag) do
+    if not (IsAsciiAlphaNumeric(Flag[i]) or (Flag[i] in ['-', '_'])) then
+      Exit(False);
+end;
+
+function IsValidShortFlag(const Flag: string): Boolean;
+begin
+  Result := (Length(Flag) = 2) and (Flag[1] = '-') and
+    (Flag[2] <> '-') and (Ord(Flag[2]) >= 33) and (Ord(Flag[2]) < 127) and
+    not (Flag[2] in ['=']);
+end;
+
+procedure ValidateCommandName(const Name, Context: string;
+  const AllowEmpty: Boolean);
+var
+  i: Integer;
+begin
+  if (Name = '') and AllowEmpty then
+    Exit;
+  if Name = '' then
+    raise EArgumentException.CreateFmt('%s name must not be empty', [Context]);
+  for i := 1 to Length(Name) do
+    if not (IsAsciiAlphaNumeric(Name[i]) or (Name[i] in ['-', '_'])) then
+      raise EArgumentException.CreateFmt(
+        '%s name "%s" contains invalid command-name token characters',
+        [Context, Name]);
+  if Name[1] = '-' then
+    raise EArgumentException.CreateFmt(
+      '%s name "%s" must not begin with a dash', [Context, Name]);
+end;
+
+procedure ValidateParameterDefinition(const Parameter: ICommandParameter;
+  const Context: string);
+begin
+  if not Assigned(Parameter) then
+    raise EArgumentNilException.CreateFmt('%s parameter cannot be nil', [Context]);
+  if (Parameter.ShortFlag = '') and (Parameter.LongFlag = '') then
+    raise EArgumentException.CreateFmt(
+      '%s parameter must define a short or long flag', [Context]);
+  if (Parameter.LongFlag <> '') and not IsValidLongFlag(Parameter.LongFlag) then
+    raise EArgumentException.CreateFmt(
+      '%s parameter has invalid long flag "%s"', [Context, Parameter.LongFlag]);
+  if (Parameter.ShortFlag <> '') and not IsValidShortFlag(Parameter.ShortFlag) then
+    raise EArgumentException.CreateFmt(
+      '%s parameter has invalid short flag "%s"', [Context, Parameter.ShortFlag]);
+end;
+
+function TreeContainsName(const Root: ICommand; const TargetName: string;
+  const Active: TStringList): Boolean;
+var
+  Children: specialize TArray<ICommand>;
+  i: Integer;
+begin
+  Result := False;
+  if not Assigned(Root) then
+    Exit;
+  if SameText(Root.Name, TargetName) then
+    Exit(True);
+  if Active.IndexOf(Root.Name) >= 0 then
+    Exit;
+  Active.Add(Root.Name);
+  try
+    Children := Root.SubCommands;
+    for i := 0 to Length(Children) - 1 do
+      if TreeContainsName(Children[i], TargetName, Active) then
+        Exit(True);
+  finally
+    Active.Delete(Active.Count - 1);
+  end;
+end;
+
+function CommandTreeContainsName(const Root: ICommand;
+  const TargetName: string): Boolean;
+var
+  Active: TStringList;
+begin
+  Active := TStringList.Create;
+  try
+    Result := TreeContainsName(Root, TargetName, Active);
+  finally
+    Active.Free;
+  end;
+end;
+
+procedure WalkCommandTree(const Current: ICommand; const Context: string;
+  const IsRoot, AllowEmptyRoot: Boolean; const Active: TStringList);
+var
+  Children: specialize TArray<ICommand>;
+  Parameters: specialize TArray<ICommandParameter>;
+  i: Integer;
+begin
+  if not Assigned(Current) then
+    raise EArgumentNilException.CreateFmt('%s contains a nil command', [Context]);
+  ValidateCommandName(Current.Name, Context + ' command', IsRoot and AllowEmptyRoot);
+  if Active.IndexOf(Current.Name) >= 0 then
+    raise EArgumentException.CreateFmt(
+      '%s contains a command cycle at "%s"', [Context, Current.Name]);
+  Active.Add(Current.Name);
+  try
+    Parameters := Current.Parameters;
+    for i := 0 to Length(Parameters) - 1 do
+      ValidateParameterDefinition(Parameters[i],
+        Context + ' command "' + Current.Name + '"');
+    Children := Current.SubCommands;
+    for i := 0 to Length(Children) - 1 do
+      WalkCommandTree(Children[i], Context, False, AllowEmptyRoot,
+        Active);
+  finally
+    Active.Delete(Active.Count - 1);
+  end;
+end;
+
+procedure ValidateCommandTree(const Command: ICommand; const Context: string;
+  const AllowEmptyRoot: Boolean);
+var
+  Active: TStringList;
+begin
+  Active := TStringList.Create;
+  try
+    WalkCommandTree(Command, Context, True, AllowEmptyRoot, Active);
+  finally
+    Active.Free;
+  end;
+end;
+
+end.

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,64 +1,80 @@
-# Implementation Plan: cli-fp v1.4.1 documentation accuracy patch
+# Implementation Plan: cli-fp v1.5.0 Defensive CLI Core
 
 ## Overview
 
-Correct the published v1.4.0 documentation so readers always see the normal
-class-based cli-fp model: define a `TBaseCommand` descendant, create its
-instance, register options on that instance, and run its `Execute` method via
-an `ICLIApplication`. This is a documentation-only release; no runtime API,
-parser, or generator behaviour changes.
+Harden the existing v1.4.3 command/parameter model, make parser failures
+predictable, secure generated output, fix confirmed value and terminal bugs,
+and publish a beginner-oriented v1.5.0 release without redesigning the
+public facade or adding positional-argument semantics.
 
-## Architecture Decisions
+## Architecture decisions
 
-- Treat the Getting Started QuickStart as the canonical full program; use
-  clearly labelled command patterns and in-context fragments elsewhere.
-- Give every reader-facing Pascal block either local declarations or an
-  explicit immediate context statement. Do not rely on implied `App`, `Root`,
-  `Command`, spinner, or progress variables.
-- Keep `docs/how-to.md` as one task-oriented page, but introduce the command
-  hierarchy there and link outward instead of duplicating full programs.
-- Keep technical documentation as source-context excerpts and label that scope
-  plainly rather than presenting implementation fragments as application code.
+- Keep validation in small shared helpers in the runtime and generator rather
+  than changing the public interfaces or adding dependencies.
+- Treat an empty command name as valid only for the configured root command;
+  named application commands and subcommands must use valid single tokens.
+- Preserve last-write-wins option parsing and reject unexpected positional
+  arguments explicitly.
+- Keep shell emitters in the current application unit for v1.5.0; defer the
+  larger renderer extraction to v1.6.x.
+- Encode Pascal strings as valid literals with `#` character fragments for
+  line breaks/control characters rather than silently corrupting generated
+  source.
 
-## Task List
+## Task list
 
-### Phase 1: Context audit and reader path
+### Phase 1: Runtime contracts and regression coverage
 
-- [ ] Task 1: Audit every published Pascal block and record its category
-  (complete program, command pattern, or explicitly scoped fragment).
-- [ ] Task 2: Add the command/object/application mental model to Getting
-  Started, Commands, and How-To; repair root, named, and nested command setup.
+- [x] Add focused tests for malformed definitions, parser edge cases, value
+  initialization, enum/date-time correctness, and help behavior.
+- [x] Add reusable command/flag validation and cycle detection while preserving
+  root-command semantics.
+- [x] Reject unexpected positional arguments and make help requests with extra
+  arguments deterministic.
+- [x] Fix case-consistent parameter lookup, literal enum splitting, documented
+  date-time format, and empty flag filtering.
 
-### Checkpoint: Reader context
+### Checkpoint: Runtime
 
-- [ ] A reader of How-To alone can identify the developer-defined
-  `TBaseCommand` descendant, the option-owning instance, and `Execute`.
-- [ ] No reader-facing Pascal block contains an unexplained identifier.
+- [x] Framework tests pass and normal root/named/nested examples still compile.
 
-### Phase 2: Recipe and reference accuracy
+### Phase 2: Output, generator, and terminal hardening
 
-- [ ] Task 3: Repair option, value-retrieval, exit-code, terminal, progress,
-  and debug recipes with exact units, receiver types, and scopes.
-- [ ] Task 4: Audit reference, technical, release, and navigation pages;
-  update v1.4.1 version records without changing runtime claims.
+- [x] Quote/escape Bash and PowerShell completion metadata and sanitize unsafe
+  terminal controls in rendered text.
+- [x] Harden generator validation, argument parsing, corrupt-manifest/spec
+  failures, and Pascal literal rendering.
+- [x] Make color reset exception-safe, bound progress width, remove spinner
+  update sleeping, and improve line clearing.
+- [x] Extend generator/completion/terminal regression tests.
 
-### Checkpoint: Documentation qualification
+### Checkpoint: Qualification
 
-- [ ] DocKit check, strict audit, and build succeed.
-- [ ] Framework, generator, and canonical-example checks succeed as applicable.
+- [x] Framework, generator, golden, compile-smoke, cleanup, completion, and
+  documentation checks pass where supported by the environment.
 
-### Phase 3: Review and release
+### Phase 3: Documentation and release
 
-- [ ] Task 5: Review the diff for documentation/API accuracy, commit the
-  candidate, and publish the authorised PR.
-- [ ] Task 6: Qualify the exact candidate in CI, merge, tag v1.4.1, create the
-  GitHub release, and verify rendered Pages content.
+- [x] Update beginner docs, limitations, API/reference pages, navigation,
+  changelog, roadmap, and DocKit version metadata for v1.5.0.
+- [x] Run review and final diff checks; commit coherent changes.
+- [ ] Push, create/check/merge PR, tag, publish release, and verify Pages if
+  GitHub authentication and required checks permit remote operations.
 
-## Risks and Mitigations
+## Deferred by design
 
-| Risk | Impact | Mitigation |
-| --- | --- | --- |
-| A concise snippet still looks standalone | High | State its category and scope immediately before it; favour the canonical QuickStart link. |
-| Documentation drifts from source | High | Compare every touched API call to `src/` and compile all existing canonical examples. |
-| Docs-only changes do not trigger tests CI | Medium | Run local qualification and manually dispatch the existing Tests workflow for the PR branch. |
-| Pages deployment masks stale content | Medium | Verify route-specific rendered text after the main-branch deploy finishes. |
+- Positional-argument APIs and `--` terminator semantics remain later design
+  work because the v1.x parser has no positional destination.
+- Per-command versioning remains unsupported; version stays application-level.
+- The major `TCLIApplication` structural split remains v1.6.x work.
+- Deprecated/no-op public completion callbacks remain source-compatible until
+  v2.0.0.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Existing valid command declarations are rejected | Validate only malformed token shapes and preserve root `''`. |
+| Shell quoting fix creates invalid scripts | Add generated-script inspection and shell syntax tests. |
+| FPC 3.2.2 differences | Use repository runners and CI-equivalent commands on Windows. |
+| Release permissions unavailable | Finish local qualification and report exact remote blocker/actions. |

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,53 +1,10 @@
-# v1.4.1 documentation accuracy tasks
+# cli-fp v1.5.0 checklist
 
-## Task 1: Audit and classify published Pascal snippets
-
-**Acceptance criteria:** Every Pascal block in a published page is classified
-as a complete program, complete command pattern, or explicitly scoped fragment;
-all identifiers have declarations or immediate context.
-
-**Verification:** Search all published Markdown files and manually inspect each
-Pascal block against the source API.
-
-**Dependencies:** None
-
-## Task 2: Establish the class-based command model
-
-**Acceptance criteria:** Getting Started, Commands, and How-To explicitly show
-`TBaseCommand` descendants, command instances, option registration, application
-registration, and `Execute`.
-
-**Verification:** Apply the supplied reader test to How-To and compile the
-canonical QuickStart example.
-
-**Dependencies:** Task 1
-
-## Task 3: Correct recipe and reference fragments
-
-**Acceptance criteria:** Options, value retrieval, exit codes, terminal output,
-spinner/progress, debug casting, API reference, and technical excerpts state
-their receiver, units, and execution scope accurately.
-
-**Verification:** Compare the touched APIs with `src/`; run DocKit checks.
-
-**Dependencies:** Tasks 1-2
-
-## Task 4: Release records and qualification
-
-**Acceptance criteria:** Version metadata, changelog, roadmap, project page,
-and v1.4.1 release notes truthfully describe a documentation-only patch; local
-documentation/framework/generator/example checks pass.
-
-**Verification:** Repository test scripts, DocKit strict audit/build, and diff
-whitespace check.
-
-**Dependencies:** Task 3
-
-## Task 5: Review, publish, and verify release
-
-**Acceptance criteria:** The candidate is reviewed, approved by checks, merged,
-tagged, released, and its rendered docs demonstrate the repaired context.
-
-**Verification:** GitHub PR/checks/release state and route-specific Pages text.
-
-**Dependencies:** Task 4
+- [x] Runtime validation and parser behavior
+- [x] Generator and completion hardening
+- [x] Console/progress robustness
+- [x] Regression tests
+- [x] Beginner and maintainer documentation
+- [x] Version/changelog/roadmap/DocKit metadata
+- [x] Local qualification and review
+- [ ] PR/merge/tag/release/Pages verification

--- a/tests/codegen/codegentestcase.pas
+++ b/tests/codegen/codegentestcase.pas
@@ -31,6 +31,10 @@ type
     procedure TestNonObjectParameterReportsItsLocation;
     procedure TestMalformedParameterDoesNotLeakOwnedSpecs;
     procedure TestRootCommandSpecRoundTrips;
+    procedure TestMalformedFlagsAreRejected;
+    procedure TestMalformedJsonFailsClearly;
+    procedure TestMalformedManifestFailsClearly;
+    procedure TestPascalStringRenderingEscapesControls;
   end;
 
 implementation
@@ -38,7 +42,9 @@ implementation
 uses
   CliFpGen.Naming,
   CliFpGen.SpecIO,
-  CliFpGen.Validate;
+  CliFpGen.Validate,
+  CliFpGen.Renderer,
+  CliFpGen.Manifest;
 
 procedure TCodegenTests.AssertSpecLoadFails(const JsonText,
   ExpectedMessagePart: string);
@@ -319,6 +325,104 @@ begin
   finally
     Spec.Free;
     DeleteFile(SpecFile);
+  end;
+end;
+
+procedure TCodegenTests.TestMalformedFlagsAreRejected;
+var
+  Spec: TProjectSpec;
+  Cmd: TCommandSpec;
+  Param: TParameterSpec;
+begin
+  Spec := NewValidSpec;
+  try
+    Cmd := AddCommand(Spec, 'run');
+    Param := TParameterSpec.Create;
+    Param.ShortFlag := '-';
+    Param.LongFlag := '--name';
+    Param.Description := 'Name';
+    Cmd.Parameters.Add(Param);
+    AssertValidationFails(Spec, 'invalid short flag');
+
+    Spec.Free;
+    Spec := NewValidSpec;
+    Cmd := AddCommand(Spec, 'run');
+    Param := TParameterSpec.Create;
+    Param.ShortFlag := '-n';
+    Param.LongFlag := '--';
+    Param.Description := 'Name';
+    Cmd.Parameters.Add(Param);
+    AssertValidationFails(Spec, 'invalid long flag');
+  finally
+    Spec.Free;
+  end;
+end;
+
+procedure TCodegenTests.TestMalformedJsonFailsClearly;
+begin
+  AssertSpecLoadFails('{', 'Invalid project spec JSON');
+end;
+
+procedure TCodegenTests.TestMalformedManifestFailsClearly;
+var
+  ProjectDir, GeneratedDir, ManifestFile: string;
+  Lines, Manifest: TStringList;
+  RaisedExpectedError: Boolean;
+begin
+  ProjectDir := GetTempFileName(GetTempDir(False), 'mft');
+  DeleteFile(ProjectDir);
+  GeneratedDir := ProjectDir + DirectorySeparator + 'src' +
+    DirectorySeparator + 'generated';
+  ForceDirectories(GeneratedDir);
+  ManifestFile := GeneratedDir + DirectorySeparator + '.clifp-manifest.json';
+  Lines := TStringList.Create;
+  try
+    Lines.Text := '{';
+    Lines.SaveToFile(ManifestFile);
+  finally
+    Lines.Free;
+  end;
+
+  RaisedExpectedError := False;
+  Manifest := nil;
+  try
+    try
+      Manifest := LoadGeneratedManifest(ProjectDir);
+    except
+      on E: Exception do
+      begin
+        RaisedExpectedError := True;
+        AssertTrue('Expected corrupt manifest error to be explicit',
+          Pos('invalid generated manifest json', LowerCase(E.Message)) > 0);
+      end;
+    end;
+    AssertTrue('Expected corrupt manifest loading to fail', RaisedExpectedError);
+  finally
+    Manifest.Free;
+    DeleteFile(ManifestFile);
+    RemoveDir(GeneratedDir);
+    RemoveDir(ExtractFileDir(GeneratedDir));
+    RemoveDir(ProjectDir);
+  end;
+end;
+
+procedure TCodegenTests.TestPascalStringRenderingEscapesControls;
+var
+  Spec: TProjectSpec;
+  Cmd: TCommandSpec;
+  Rendered: string;
+begin
+  Spec := NewValidSpec;
+  try
+    Cmd := AddCommand(Spec, 'greet');
+    Cmd.Description := 'O''Reilly' + #13#10 + 'second line';
+    Rendered := RenderRegistryUnit(Spec);
+    AssertTrue('Generated Pascal should escape apostrophes',
+      Pos('O''''Reilly', Rendered) > 0);
+    AssertTrue('Generated Pascal should encode newlines',
+      Pos('#13 + #10', Rendered) > 0);
+  finally
+    Spec.Free;
   end;
 end;
 

--- a/tests/testcase.pas
+++ b/tests/testcase.pas
@@ -8,7 +8,7 @@ uses
   Classes, SysUtils, fpcunit, testregistry,
   CLI.Interfaces,
   CLI.Application, CLI.Command, CLI.Parameter,
-  CLI.Progress, CLI.Console;
+  CLI.Progress, CLI.Console, CLI.Internal.Text;
 
 type
   { TCLIFrameworkTests }
@@ -78,10 +78,21 @@ type
 
     // 8.x - v1.4.2 Regression Tests
     procedure Test_8_1_ProgressBarBounds;
-    procedure Test_8_2_FlagCaseSensitivity;
+    procedure Test_8_2_FlagCaseInsensitiveLookup;
     procedure Test_8_3_CompletionAlwaysReturnsDirective;
     procedure Test_8_4_CompletionScriptQuotingAndHeader;
     procedure Test_8_5_DateTimeValidationDoesNotChangeFormatSettings;
+
+    // 9.x - v1.5.0 Defensive CLI Core
+    procedure Test_9_1_InvalidRegisteredCommand;
+    procedure Test_9_2_NilRegisteredCommand;
+    procedure Test_9_3_InvalidParameterFlags;
+    procedure Test_9_4_DuplicateParameterFlags;
+    procedure Test_9_5_InvalidSubcommandTrees;
+    procedure Test_9_6_PositionalArgumentsAndDuplicateOptions;
+    procedure Test_9_7_HelpExtraArgumentsAndValueMiss;
+    procedure Test_9_8_EnumValuesMayContainSpaces;
+    procedure Test_9_9_TerminalTextSanitization;
   end;
 
 implementation
@@ -1237,9 +1248,20 @@ begin
   finally
     Progress.Free;
   end;
+
+  Progress := TRecordingProgressBar.Create(1, MaxProgressBarWidth + 1000);
+  try
+    Progress.Start;
+    Progress.Update(1);
+    AssertTrue('Pathological progress widths should be capped',
+      Length(Progress.LastText) <= MaxProgressBarWidth + 10);
+    Progress.Stop;
+  finally
+    Progress.Free;
+  end;
 end;
 
-procedure TCLIFrameworkTests.Test_8_2_FlagCaseSensitivity;
+procedure TCLIFrameworkTests.Test_8_2_FlagCaseInsensitiveLookup;
 var
   App: TCLIApplication;
   Cmd: TRecordingCommand;
@@ -1253,8 +1275,10 @@ begin
       App.TestExecute(MakeArgs(['test', '--name', 'Ada'])));
     AssertEquals('Exact-case flag value should be available to the command',
       'Ada', Cmd.LastName);
-    AssertEquals('Different-case flags should be rejected consistently', 1,
+    AssertEquals('Different-case flags should match the public lookup rules', 0,
       App.TestExecute(MakeArgs(['test', '--NAME', 'Ada'])));
+    AssertEquals('Case-insensitive flag lookup should provide the value',
+      'Ada', Cmd.LastName);
   finally
     App.Free;
   end;
@@ -1357,6 +1381,258 @@ begin
     FormatSettings.DateSeparator := OriginalDateSeparator;
     FormatSettings.ShortDateFormat := OriginalShortDateFormat;
     FormatSettings.LongTimeFormat := OriginalLongTimeFormat;
+  end;
+end;
+
+procedure TCLIFrameworkTests.Test_9_1_InvalidRegisteredCommand;
+var
+  Cmd: TTestCommand;
+  Raised: Boolean;
+begin
+  Cmd := TTestCommand.Create('bad command', 'Invalid command');
+  Raised := False;
+  try
+    try
+      FApp.RegisterCommand(Cmd);
+    except
+      on E: Exception do
+        Raised := Pos('invalid command-name', LowerCase(E.Message)) > 0;
+    end;
+  finally
+    Cmd.Free;
+  end;
+  AssertTrue('Invalid registered command names should fail clearly', Raised);
+end;
+
+procedure TCLIFrameworkTests.Test_9_2_NilRegisteredCommand;
+var
+  Cmd: ICommand;
+  Raised: Boolean;
+begin
+  Cmd := nil;
+  Raised := False;
+  try
+    FApp.RegisterCommand(Cmd);
+  except
+    on E: Exception do
+      Raised := Pos('cannot be nil', LowerCase(E.Message)) > 0;
+  end;
+  AssertTrue('Nil registered commands should be rejected', Raised);
+end;
+
+procedure TCLIFrameworkTests.Test_9_3_InvalidParameterFlags;
+var
+  Cmd: TTestCommand;
+  Raised: Boolean;
+begin
+  Cmd := TTestCommand.Create('test', 'Test command');
+  try
+    Raised := False;
+    try
+      Cmd.AddStringParameter('-', '--name', 'Invalid short flag');
+    except
+      on E: Exception do Raised := True;
+    end;
+    AssertTrue('Bare short flags should be rejected', Raised);
+
+    Raised := False;
+    try
+      Cmd.AddStringParameter('-n', '--', 'Invalid long flag');
+    except
+      on E: Exception do Raised := True;
+    end;
+    AssertTrue('Bare long flags should be rejected', Raised);
+
+    Raised := False;
+    try
+      Cmd.AddStringParameter('-x', '--bad name', 'Whitespace in flag');
+    except
+      on E: Exception do Raised := True;
+    end;
+    AssertTrue('Whitespace in flags should be rejected', Raised);
+  finally
+    Cmd.Free;
+  end;
+end;
+
+procedure TCLIFrameworkTests.Test_9_4_DuplicateParameterFlags;
+var
+  Cmd: TTestCommand;
+  Raised: Boolean;
+begin
+  Cmd := TTestCommand.Create('test', 'Test command');
+  try
+    Cmd.AddStringParameter('-n', '--name', 'Name');
+    Raised := False;
+    try
+      Cmd.AddStringParameter('-N', '--other', 'Duplicate short flag');
+    except
+      on E: Exception do Raised := True;
+    end;
+    AssertTrue('Duplicate short flags should be case-insensitive', Raised);
+
+    Raised := False;
+    try
+      Cmd.AddStringParameter('-o', '--NAME', 'Duplicate long flag');
+    except
+      on E: Exception do Raised := True;
+    end;
+    AssertTrue('Duplicate long flags should be case-insensitive', Raised);
+  finally
+    Cmd.Free;
+  end;
+end;
+
+procedure TCLIFrameworkTests.Test_9_5_InvalidSubcommandTrees;
+var
+  Parent, Child, Duplicate, Invalid: TTestCommand;
+  NilCommand: ICommand;
+  Raised: Boolean;
+begin
+  Parent := TTestCommand.Create('parent', 'Parent');
+  Child := TTestCommand.Create('child', 'Child');
+  Duplicate := TTestCommand.Create('CHILD', 'Duplicate child');
+  Invalid := TTestCommand.Create('bad child', 'Invalid child');
+  try
+    NilCommand := nil;
+    Raised := False;
+    try
+      Parent.AddSubCommand(NilCommand);
+    except
+      on E: Exception do Raised := Pos('cannot be nil', LowerCase(E.Message)) > 0;
+    end;
+    AssertTrue('Nil subcommands should be rejected', Raised);
+
+    Raised := False;
+    try
+      Parent.AddSubCommand(Invalid);
+    except
+      on E: Exception do Raised := True;
+    end;
+    AssertTrue('Invalid subcommand names should be rejected', Raised);
+
+    Raised := False;
+    try
+      Parent.AddSubCommand(Parent);
+    except
+      on E: Exception do Raised := Pos('cycle', LowerCase(E.Message)) > 0;
+    end;
+    AssertTrue('A command cannot be its own child', Raised);
+
+    Parent.AddSubCommand(Child);
+    Raised := False;
+    try
+      Parent.AddSubCommand(Duplicate);
+    except
+      on E: Exception do Raised := Pos('already defined', LowerCase(E.Message)) > 0;
+    end;
+    AssertTrue('Duplicate sibling subcommands should be rejected', Raised);
+
+    Raised := False;
+    try
+      Child.AddSubCommand(Parent);
+    except
+      on E: Exception do Raised := Pos('cycle', LowerCase(E.Message)) > 0;
+    end;
+    AssertTrue('Indirect command cycles should be rejected', Raised);
+  finally
+    Parent.Free;
+    Duplicate.Free;
+    Invalid.Free;
+  end;
+end;
+
+procedure TCLIFrameworkTests.Test_9_6_PositionalArgumentsAndDuplicateOptions;
+var
+  App: TCLIApplication;
+  Cmd: TRecordingCommand;
+begin
+  App := TCLIApplication.Create('TestApp', '1.5.0');
+  Cmd := TRecordingCommand.Create('test', 'Test command');
+  try
+    Cmd.AddStringParameter('-n', '--name', 'Name');
+    App.RegisterCommand(Cmd);
+    AssertEquals('Unexpected positional arguments should fail with exit code 1',
+      1, App.TestExecute(MakeArgs(['test', 'foo'])));
+    AssertEquals('Positional argument rejection should not execute the command',
+      '', Cmd.LastName);
+    AssertEquals('Duplicate options should use the last occurrence', 0,
+      App.TestExecute(MakeArgs(['test', '--name', 'Alice', '--name', 'Bob'])));
+    AssertEquals('Last option value should win', 'Bob', Cmd.LastName);
+  finally
+    App.Free;
+  end;
+end;
+
+procedure TCLIFrameworkTests.Test_9_7_HelpExtraArgumentsAndValueMiss;
+var
+  App: TCLIApplication;
+  Cmd: TTestCommand;
+  Output: TStringList;
+  Value: string;
+begin
+  App := TCLIApplication.Create('TestApp', '1.5.0');
+  Cmd := TTestCommand.Create('test', 'Test command');
+  Output := TStringList.Create;
+  try
+    App.RegisterCommand(Cmd);
+    AssertEquals('Global help with extra arguments should be deterministic', 0,
+      App.TestExecuteAndCapture(MakeArgs(['--help', 'extra']), Output));
+    AssertTrue('Global help should still be shown with extra arguments',
+      Pos('Usage:', Output.Text) > 0);
+    Value := 'stale';
+    AssertFalse('Missing command parameter should report a miss',
+      Cmd.TestGetParameterValue('--missing', Value));
+    AssertEquals('Missing parameter lookup should clear the out value', '', Value);
+  finally
+    Output.Free;
+    App.Free;
+  end;
+end;
+
+procedure TCLIFrameworkTests.Test_9_8_EnumValuesMayContainSpaces;
+var
+  App: TCLIApplication;
+  Cmd: TTestCommand;
+begin
+  App := TCLIApplication.Create('TestApp', '1.5.0');
+  Cmd := TTestCommand.Create('test', 'Test command');
+  try
+    Cmd.AddEnumParameter('-m', '--mode', 'Mode', 'normal mode|fast mode');
+    App.RegisterCommand(Cmd);
+    AssertEquals('Enum values containing spaces should validate', 0,
+      App.TestExecute(MakeArgs(['test', '--mode', 'normal mode'])));
+  finally
+    App.Free;
+  end;
+end;
+
+procedure TCLIFrameworkTests.Test_9_9_TerminalTextSanitization;
+var
+  App: TCLIApplication;
+  Cmd: TTestCommand;
+  Output: TStringList;
+begin
+  AssertEquals('Terminal sanitization should remove ESC and NUL while preserving text',
+    'Safe[31m' + #13#10 + '✓',
+    SanitizeTerminalText('Safe' + #27 + '[31m' + #0 + #13#10 + '✓'));
+
+  App := TCLIApplication.Create('TestApp', '1.5.0');
+  Cmd := TTestCommand.Create('safe', 'Description' + #27 + '[31m' + #0);
+  Output := TStringList.Create;
+  try
+    App.RegisterCommand(Cmd);
+    AssertEquals('Help should remain available for sanitized descriptions', 0,
+      App.TestExecuteAndCapture(MakeArgs(['--help']), Output));
+    AssertTrue('Help should preserve printable description text',
+      Pos('Description[31m', Output.Text) > 0);
+    AssertEquals('Captured help should contain no ESC characters', 0,
+      Pos(#27, Output.Text));
+    AssertEquals('Captured help should contain no NUL characters', 0,
+      Pos(#0, Output.Text));
+  finally
+    Output.Free;
+    App.Free;
   end;
 end;
 

--- a/tools/cli-fp-gen/src/clifpgen.app.pas
+++ b/tools/cli-fp-gen/src/clifpgen.app.pas
@@ -157,11 +157,6 @@ begin
       Inc(i);
       if i > ParamCount then raise Exception.Create('--description requires a value');
       Description := ArgOrEmpty(i);
-      while (i < ParamCount) and (Copy(ArgOrEmpty(i + 1), 1, 2) <> '--') do
-      begin
-        Inc(i);
-        Description := Description + ' ' + ArgOrEmpty(i);
-      end;
     end
     else if Arg = '--project' then
     begin

--- a/tools/cli-fp-gen/src/clifpgen.manifest.pas
+++ b/tools/cli-fp-gen/src/clifpgen.manifest.pas
@@ -122,13 +122,24 @@ begin
   if not FileExists(FileName) then
     Exit;
 
-  Root := GetJSON(ReadTextFileStrict(FileName));
+  try
+    Root := GetJSON(ReadTextFileStrict(FileName));
+  except
+    on E: Exception do
+      raise Exception.CreateFmt('Invalid generated manifest JSON in %s: %s',
+        [FileName, E.Message]);
+  end;
   try
     if not (Root is TJSONObject) then
-      Exit;
+      raise Exception.CreateFmt(
+        'Invalid generated manifest in %s: root must be an object', [FileName]);
     Obj := TJSONObject(Root);
-    if (Obj.Find('generatedFiles') = nil) or not (Obj.Arrays['generatedFiles'] is TJSONArray) then
-      Exit;
+    if Obj.Find('generatedFiles') = nil then
+      raise Exception.CreateFmt(
+        'Invalid generated manifest in %s: generatedFiles is required', [FileName]);
+    if not (Obj.Find('generatedFiles') is TJSONArray) then
+      raise Exception.CreateFmt(
+        'Invalid generated manifest in %s: generatedFiles must be an array', [FileName]);
     Arr := Obj.Arrays['generatedFiles'];
     for i := 0 to Arr.Count - 1 do
       Result.Add(NormalizeRelPath(Arr.Strings[i]));

--- a/tools/cli-fp-gen/src/clifpgen.naming.pas
+++ b/tools/cli-fp-gen/src/clifpgen.naming.pas
@@ -231,6 +231,8 @@ begin
   Result := False;
   if S = '' then
     Exit;
+  if S[1] = '-' then
+    Exit;
   for i := 1 to Length(S) do
   begin
     Ch := S[i];

--- a/tools/cli-fp-gen/src/clifpgen.renderer.pas
+++ b/tools/cli-fp-gen/src/clifpgen.renderer.pas
@@ -23,8 +23,38 @@ begin
 end;
 
 function PascalStringLiteral(const S: string): string;
+var
+  i: Integer;
+  Chunk: string;
+
+  procedure AppendPart(const Part: string);
+  begin
+    if Result <> '' then
+      Result := Result + ' + ';
+    Result := Result + Part;
+  end;
+
 begin
-  Result := '''' + StringReplace(S, '''', '''''', [rfReplaceAll]) + '''';
+  Result := '';
+  Chunk := '';
+  for i := 1 to Length(S) do
+  begin
+    if (Ord(S[i]) < 32) or (Ord(S[i]) = 127) then
+    begin
+      if Chunk <> '' then
+      begin
+        AppendPart('''' + StringReplace(Chunk, '''', '''''', [rfReplaceAll]) + '''');
+        Chunk := '';
+      end;
+      AppendPart('#' + IntToStr(Ord(S[i])));
+    end
+    else
+      Chunk := Chunk + S[i];
+  end;
+  if Chunk <> '' then
+    AppendPart('''' + StringReplace(Chunk, '''', '''''', [rfReplaceAll]) + '''');
+  if Result = '' then
+    Result := '''''';
 end;
 
 function PascalBoolLiteral(const B: Boolean): string;

--- a/tools/cli-fp-gen/src/clifpgen.specio.pas
+++ b/tools/cli-fp-gen/src/clifpgen.specio.pas
@@ -111,7 +111,13 @@ begin
     raise Exception.CreateFmt('Spec file not found: %s', [SpecFile]);
 
   JsonText := ReadTextFileStrict(SpecFile);
-  Root := GetJSON(JsonText);
+  try
+    Root := GetJSON(JsonText);
+  except
+    on E: Exception do
+      raise Exception.CreateFmt('Invalid project spec JSON in %s: %s',
+        [SpecFile, E.Message]);
+  end;
   try
     if not (Root is TJSONObject) then
       raise Exception.Create('Invalid spec: root must be a JSON object');
@@ -139,8 +145,10 @@ begin
           Result.RootCommand.Parameters);
       end;
 
-      if (RootObj.Find('commands') <> nil) and (RootObj.Arrays['commands'] is TJSONArray) then
+      if RootObj.Find('commands') <> nil then
       begin
+        if not (RootObj.Find('commands') is TJSONArray) then
+          raise Exception.Create('Invalid spec: commands must be an array');
         CmdArray := RootObj.Arrays['commands'];
         for i := 0 to CmdArray.Count - 1 do
         begin

--- a/tools/cli-fp-gen/src/clifpgen.validate.pas
+++ b/tools/cli-fp-gen/src/clifpgen.validate.pas
@@ -19,6 +19,30 @@ begin
   Result := Copy(S, 1, Length(Prefix)) = Prefix;
 end;
 
+function IsAsciiAlphaNumeric(const C: Char): Boolean;
+begin
+  Result := C in ['A'..'Z', 'a'..'z', '0'..'9'];
+end;
+
+function IsValidLongFlag(const Flag: string): Boolean;
+var
+  i: Integer;
+begin
+  Result := (Length(Flag) >= 3) and (Copy(Flag, 1, 2) = '--') and
+    IsAsciiAlphaNumeric(Flag[3]);
+  if not Result then Exit;
+  for i := 3 to Length(Flag) do
+    if not (IsAsciiAlphaNumeric(Flag[i]) or (Flag[i] in ['-', '_'])) then
+      Exit(False);
+end;
+
+function IsValidShortFlag(const Flag: string): Boolean;
+begin
+  Result := (Length(Flag) = 2) and (Flag[1] = '-') and
+    (Flag[2] <> '-') and (Ord(Flag[2]) >= 33) and (Ord(Flag[2]) < 127) and
+    not (Flag[2] in ['=']);
+end;
+
 function IsAbsoluteLikePath(const S: string): Boolean;
 begin
   Result := (ExtractFileDrive(S) <> '') or
@@ -58,19 +82,14 @@ begin
     begin
       Param := Parameters[j];
 
-      if Trim(Param.LongFlag) = '' then
-        raise Exception.CreateFmt('%s: parameter %d missing long flag',
+      if (Trim(Param.ShortFlag) = '') and (Trim(Param.LongFlag) = '') then
+        raise Exception.CreateFmt('%s: parameter %d must define a short or long flag',
           [CommandLabel, j]);
-      if not StartsWith(Param.LongFlag, '--') then
+      if not IsValidLongFlag(Param.LongFlag) then
         raise Exception.CreateFmt('%s: invalid long flag "%s"',
           [CommandLabel, Param.LongFlag]);
-      if (Trim(Param.ShortFlag) <> '') and
-        (not StartsWith(Param.ShortFlag, '-')) then
+      if (Trim(Param.ShortFlag) <> '') and not IsValidShortFlag(Param.ShortFlag) then
         raise Exception.CreateFmt('%s: invalid short flag "%s"',
-          [CommandLabel, Param.ShortFlag]);
-      if StartsWith(Param.ShortFlag, '--') then
-        raise Exception.CreateFmt(
-          '%s: short flag must be single-dash style ("%s")',
           [CommandLabel, Param.ShortFlag]);
 
       if Trim(Param.Description) = '' then


### PR DESCRIPTION
## Summary

- Harden command, parameter, duplicate, nil, and cycle validation.
- Reject unexpected positional arguments while preserving last-option-wins semantics.
- Fix case-consistent lookup, enum delimiters, missing-value initialization, and datetime help consistency.
- Harden Bash/PowerShell/Pascal rendering and terminal control handling.
- Bound progress widths, remove spinner update sleeping, and honor redirected output/NO_COLOR.
- Improve beginner setup, ownership, root-command, and troubleshooting documentation.

## Compatibility

The class-based ICLIApplication/TBaseCommand facade remains unchanged. Root, named, and nested commands remain supported. Positional APIs, -- terminator semantics, per-command versions, major application restructuring, and removal of deprecated APIs are deferred.

## Qualification

- Framework: 57/57 tests passed.
- Generator: unit, golden, compile-smoke, and ops checks passed.
- Windows example cleanup smoke: 8 examples passed.
- Lazarus package build passed.
- Bash and PowerShell syntax checks passed.
- DocKit JSON/path and Markdown checks passed.
- Linux qualification is delegated to the required GitHub Actions job.

## Security/output hardening

Terminal ESC/NUL text is sanitized; completion metadata is quoted; generated Pascal strings encode apostrophes and controls; malformed JSON/manifests fail clearly without silent fallback.
