### PR TITLE
Release cli-fp v1.5.1 — Correctness and Completion Patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-09-12
+
+### Fixed
+
+- `TBaseCommand.GetParameterValue` now honors documented case-insensitive
+  lookup for long and short flags while retaining deterministic misses.
+- Completion no longer emits empty suggestions for short-only or long-only
+  parameters.
+- Named-command `--version`/`-v` are rejected as command options; the
+  application-level version request remains supported.
+
+### Documentation
+
+- Current command-model wording now describes normal cli-fp 1.x applications
+  without tying the model to v1.4.x.
+- The API reference labels `GetParameterValue` as a protected member for
+  command descendants and current completion guidance matches runtime behavior.
+
 ## [1.5.0] - 2026-09-11
 
 ### Added
@@ -511,7 +529,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README with quick start guide
 - System requirements and compatibility information
 
-[Unreleased]: https://github.com/ikelaiah/cli-fp/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/ikelaiah/cli-fp/compare/v1.5.1...HEAD
+[1.5.1]: https://github.com/ikelaiah/cli-fp/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/ikelaiah/cli-fp/compare/v1.4.3...v1.5.0
 [1.4.3]: https://github.com/ikelaiah/cli-fp/compare/v1.4.2...v1.4.3
 [1.4.2]: https://github.com/ikelaiah/cli-fp/compare/v1.4.1...v1.4.2

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Lazarus](https://img.shields.io/badge/Lazarus-package-60A5FA.svg)](https://github.com/ikelaiah/cli-fp/blob/main/packages/lazarus/cli_fp.lpk)
 ![Supports Windows](https://img.shields.io/badge/support-Windows-F59E0B?logo=Windows)
 ![Supports Linux](https://img.shields.io/badge/support-Linux-F59E0B?logo=Linux)
-[![Version](https://img.shields.io/badge/version-1.5.0-8B5CF6.svg)](https://github.com/ikelaiah/cli-fp/blob/main/CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.5.1-8B5CF6.svg)](https://github.com/ikelaiah/cli-fp/blob/main/CHANGELOG.md)
 [![Documentation](https://img.shields.io/badge/Docs-Website-brightgreen.svg)](https://ikelaiah.github.io/cli-fp/)
 [![Tests](https://github.com/ikelaiah/cli-fp/actions/workflows/tests.yml/badge.svg)](https://github.com/ikelaiah/cli-fp/actions/workflows/tests.yml)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -162,6 +162,18 @@ common task without guessing which manual or reference page contains it.
 **Maintenance outcome:** valid v1.x CLIs remain familiar while malformed
 definitions and unsafe edge cases fail predictably.
 
+## v1.5.1 — Correctness and Completion Patch (completed 2026-09-12)
+
+- Align direct option lookup with the parser's case-insensitive flag semantics.
+- Keep completion free of empty flag candidates for one-form parameters.
+- Keep version explicitly application-level in validation and completion.
+- Clarify current API and learning documentation without changing the public
+  facade.
+
+**Maintenance outcome:** existing v1.x command implementations keep their
+runtime shape while lookup, completion, and built-in version boundaries are
+consistent and predictable.
+
 ## v1.6.0 — Finish the Application Core Boundaries
 
 - Continue internal architecture cleanup without changing the public facade.

--- a/docs/RELEASE_NOTES_v1.5.1.md
+++ b/docs/RELEASE_NOTES_v1.5.1.md
@@ -1,0 +1,26 @@
+# cli-fp v1.5.1 — Correctness and Completion Patch
+
+cli-fp v1.5.1 is a focused maintenance release for the existing 1.x command
+model.
+
+## Fixed
+
+- Direct `TBaseCommand.GetParameterValue` lookups are case-insensitive for
+  both short and long flags, and missing lookups clear their output value.
+- Completion omits empty candidates when a parameter has only one flag form.
+- `--version` and `-v` remain application-level requests. Named commands now
+  reject them during validation and do not advertise them in completion.
+
+## Documentation and metadata
+
+- Updated active documentation, package metadata, changelog, roadmap, and the
+  DocKit version registry for 1.5.1.
+- Preserved the v1.5.0 and older versioned documentation entries and release
+  history.
+
+## Compatibility and scope
+
+This patch does not change the public facade or normal class-based command
+model. Positional arguments, the `--` terminator, per-command versions, typed
+getters, execution redesign, custom completion callbacks, and other v1.6+/v2
+work remain deferred.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -74,17 +74,25 @@ are no-op compatibility members in 1.x—see [limitations](limitations.md).
 ### `TBaseCommand`
 
 ```pascal
+{ Public members }
 constructor Create(const AName, ADescription: string);
 function Execute: Integer; virtual; abstract;
 procedure AddSubCommand(const Command: ICommand);
+```
+
+Protected members for descendants:
+
+```pascal
+protected
 function GetParameterValue(const Flag: string; out Value: string): Boolean;
 ```
 
 Subclass `TBaseCommand`, override `Execute`, register options during setup,
 and return `0` on success. Use an empty `AName` for a root command.
 
-`GetParameterValue` is protected, so call it from your descendant's `Execute`.
-It finds either registered flag spelling and returns values as strings.
+`GetParameterValue` is a protected member for command descendants, so call it
+from your descendant's `Execute`. It finds either registered flag spelling and
+returns values as strings.
 Lookup is case-insensitive; a missing value returns `False` and clears the
 output string.
 
@@ -189,4 +197,4 @@ Definitions are validated when commands are registered or parameters are
 added. Invalid names, flags, duplicate siblings/options, nil commands, and
 command-tree cycles raise developer-facing exceptions. The parser rejects
 unexpected positional arguments with exit code `1`; it does not implement the
-`--` terminator in v1.5.0.
+`--` terminator in v1.x.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -167,7 +167,8 @@ does not receive options from its children. For a runnable nested example, see
 
 `tool --help` shows application help. `tool greet --help` shows the selected
 command. `--version` is an application-level request when used as the first
-argument. Return `0` from a command's `Execute` for success and a non-zero
+argument; named commands do not accept it as a command option. Return `0` from
+a command's `Execute` for success and a non-zero
 integer for an application failure; the setup fragments use `Halt(App.Execute)`
 to forward that result to the shell. The application owns registered commands
 through its interfaces, so do not manually free them.

--- a/docs/completion-testing/BASH_COMPLETION_GUIDE.md
+++ b/docs/completion-testing/BASH_COMPLETION_GUIDE.md
@@ -109,24 +109,24 @@ $ ./SubCommandDemo.exe repo clone --url https://example.com [TAB][TAB]
 **Will work:**
 ```bash
 $ ./SubCommandDemo.exe repo clone --url https://example.com -[TAB][TAB]
---branch   --depth    --help     --path     --url      --version  -b  -d  -h  -p  -u  -v
+--branch   --depth    --help     --path     --url       -b  -d  -h  -p  -u
 ```
 
 This is standard Bash completion behavior - the shell needs something to complete.
 
 #### 3. Application Flags in Command Contexts
 
-The completion engine offers `--help`, `--version`, `-h`, and `-v` while
-completing flags at a named command:
+The completion engine offers `--help` and `-h` while completing flags at a
+named command:
 
 ```bash
 $ ./SubCommandDemo.exe repo init -[TAB][TAB]
---bare     --help     --path     --version  -b         -h         -p         -v
+--bare     --help     --path                 -b         -h         -p
 ```
 
-`--help` and `-h` work at any command level. Version output is currently an
-application-level operation, so `--version` and `-v` must be the executable's
-only argument even though completion also offers them in command contexts.
+`--help` and `-h` work at any command level. Version output is an
+application-level operation: `--version` and `-v` are available only as the
+executable's standalone request and are not command options.
 
 #### 4. Short Flags Don't Auto-Complete Further
 
@@ -163,11 +163,11 @@ $ ./SubCommandDemo.exe repo [TAB][TAB]
 ```bash
 # Show all long flags (starting with --)
 $ ./SubCommandDemo.exe repo init --[TAB][TAB]
-→ --bare  --help  --path  --version
+→ --bare  --help  --path
 
 # Show all flags (both long and short)
 $ ./SubCommandDemo.exe repo init -[TAB][TAB]
-→ --bare  --help  --path  --version  -b  -h  -p  -v
+→ --bare  --help  --path  -b  -h  -p
 
 # Complete flag by prefix
 $ ./SubCommandDemo.exe repo init --p[TAB]
@@ -196,7 +196,7 @@ $ ./SubCommandDemo.exe repo remote [TAB][TAB]
 → add  remove  --help  -h
 
 $ ./SubCommandDemo.exe repo remote add -[TAB][TAB]
-→ --help  --name  --url  --version  -h  -n  -u  -v
+→ --help  --name  --url  -h  -n  -u
 ```
 
 ---
@@ -216,7 +216,7 @@ $ ./SubCommandDemo.exe repo clone --url https://test.com --branch main -[TAB][TA
 Type `--` to see only long-form flags (more readable):
 ```bash
 $ ./SubCommandDemo.exe repo init --[TAB][TAB]
-→ --bare  --help  --path  --version  (easier to read than short forms)
+→ --bare  --help  --path  (easier to read than short forms)
 ```
 
 ### 3. Prefix Matching is Case-Insensitive
@@ -284,7 +284,7 @@ The framework automatically prevents duplicates, but bash may show both short an
 | `./app cmd --value -[TAB]` | Shows available flags | Prefix provided for matching |
 | Short flag like `-b[TAB]` | May show values (true/false) | Flag is complete, offering values |
 | `--vers[TAB]` | Completes to `--version` | Prefix matching |
-| Flags at a named command | Completion offers help and version flags | Help works at command level; version is standalone only |
+| Flags at a named command | Completion offers help flags | Version is standalone only |
 
 ---
 
@@ -298,7 +298,8 @@ The framework automatically prevents duplicates, but bash may show both short an
 
 ❌ **DON'T:**
 - Expect completions after a value without typing `-` or `--`
-- Treat a suggested command-level `--version` as valid; version is standalone
+- Do not expect named-command completion to include `--version` or `-v`; they
+  are standalone application requests only
 - Forget to source the completion script in new shells
 
 For more help, run `./SubCommandDemo.exe --help` or consult the framework documentation.

--- a/docs/completion-testing/PS_COMPLETION_GUIDE.md
+++ b/docs/completion-testing/PS_COMPLETION_GUIDE.md
@@ -130,17 +130,17 @@ This is standard PowerShell completion behavior - the shell needs something to c
 
 #### 3. Application Flags in Command Contexts
 
-The completion engine offers `--help`, `--version`, `-h`, and `-v` while
-completing flags at a named command:
+The completion engine offers `--help` and `-h` while completing flags at a
+named command:
 
 ```powershell
 PS> .\SubCommandDemo.exe repo init --[TAB]
-# Cycles through: --path, --bare, --help, --version
+# Cycles through: --path, --bare, --help, -h
 ```
 
-`--help` and `-h` work at any command level. Version output is currently an
-application-level operation, so `--version` and `-v` must be the executable's
-only argument even though completion also offers them in command contexts.
+`--help` and `-h` work at any command level. Version output is an
+application-level operation: `--version` and `-v` are available only as the
+executable's standalone request and are not command options.
 
 #### 4. Command Groups Have No Flags
 
@@ -148,7 +148,7 @@ Some commands are "command groups" that contain subcommands but have no flags of
 
 ```powershell
 PS> .\SubCommandDemo.exe repo --[TAB]
-# Shows only: --help, --version (global flags)
+# Shows only: --help, -h (global flags)
 # No repo-specific flags because repo is a command group
 ```
 
@@ -230,14 +230,14 @@ PS> .\SubCommandDemo.exe repo c[TAB]     # Completes to: clone
 Typing `--` shows only long-form flags:
 ```powershell
 PS> .\SubCommandDemo.exe repo init --[TAB]
-# Shows: --path, --bare, --help, --version (no short flags)
+# Shows: --path, --bare, --help (no short flags)
 ```
 
 ### 4. Use `-` for All Flags
 Typing `-` shows both short and long flags:
 ```powershell
 PS> .\SubCommandDemo.exe repo init -[TAB]
-# Shows: --path, -p, --bare, -b, --help, -h, --version, -v
+# Shows: --path, -p, --bare, -b, --help, -h
 ```
 
 ---
@@ -297,7 +297,7 @@ Set-PSReadLineKeyHandler -Key Tab -Function MenuComplete
 | **Root Completion** | Commands only (without prefix) | Commands only (without prefix) |
 | **Case Sensitivity** | Case-insensitive | Case-insensitive |
 | **Reverse Cycling** | SHIFT+TAB | N/A (shows all) |
-| **Application Flags** | Help and version flags are offered in command contexts | Same |
+| **Application Flags** | Help flags are offered in command contexts | Version is standalone only |
 | **Boolean Values** | `true`/`false` | `true`/`false` |
 
 ---
@@ -346,7 +346,8 @@ Key points to remember:
 3. **SHIFT+TAB**: Goes backwards through options
 4. **Prefix required**: Type `-` or `--` after values to see flags
 5. **Case-insensitive**: Uppercase and lowercase both work
-6. **Application flags**: completion offers help and version flags in command contexts; version execution is standalone
+6. **Application flags**: completion offers help in command contexts; version
+   execution and completion are standalone application behavior
 
 ---
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -5,7 +5,7 @@ Short, supported recipes for common `cli-fp` tasks. Start with
 
 ## The command model used by every recipe
 
-Normal v1.4.x applications are class-based. You define a descendant, create
+Normal cli-fp 1.x applications are class-based. You define a descendant, create
 an object of that class, register its options on that object, then register the
 object with the application:
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -2,7 +2,7 @@
 
 [How do I...?](how-to.md) · [Commands](commands.md) · [Options](options.md)
 
-These are current v1.5.0 boundaries verified against the public source and
+These are current v1.5.1 boundaries verified against the public source and
 tests. They are intentionally easy to find so a limitation does not look like
 an undocumented feature.
 

--- a/docs/project.md
+++ b/docs/project.md
@@ -1,7 +1,7 @@
 # Contributing and support
 
 `cli-fp` is a small open-source framework maintained around a deliberately
-small public API. v1.5.0 is a defensive correctness release: the supported
+small public API. v1.5.1 is a correctness and completion patch: the supported
 runtime remains the class-based API described in these guides.
 
 ## Supported environments

--- a/docs/technical-docs.md
+++ b/docs/technical-docs.md
@@ -620,9 +620,9 @@ Accessible via the `--completion-file` global flag, this generator outputs a Bas
 - At the root level, an option prefix includes root-command parameters and all
   application options: `--help`, `-h`, `--help-complete`, `--version`, `-v`,
   `--completion-file`, and `--completion-file-pwsh`.
-- At named command levels, an empty token offers subcommands, command
-  parameters, and help; an option prefix currently also offers `--version` and
-  `-v`.
+  - At named command levels, an empty token offers subcommands, command
+  parameters, and help; `--version` and `-v` remain application-level requests
+  and are not command options.
 - The shell function calls the executable's hidden `__complete` entrypoint for
   live candidates. A static associative tree is still emitted for
   compatibility but is not read by the generated function.

--- a/docs/technical-docs.md
+++ b/docs/technical-docs.md
@@ -620,7 +620,7 @@ Accessible via the `--completion-file` global flag, this generator outputs a Bas
 - At the root level, an option prefix includes root-command parameters and all
   application options: `--help`, `-h`, `--help-complete`, `--version`, `-v`,
   `--completion-file`, and `--completion-file-pwsh`.
-  - At named command levels, an empty token offers subcommands, command
+- At named command levels, an empty token offers subcommands, command
   parameters, and help; `--version` and `-v` remain application-level requests
   and are not command options.
 - The shell function calls the executable's hidden `__complete` entrypoint for

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -1,6 +1,6 @@
 # cli-fp user manual
 
-This page remains as a stable starting point for existing links. The v1.5.0
+This page remains as a stable starting point for existing links. The v1.5.1
 documentation is organized by the job you want to do rather than as one long
 manual.
 

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,7 +1,8 @@
 {
   "schema_version": 1,
-  "current": "1.5.0",
+  "current": "1.5.1",
   "versions": [
+    {"release": "1.5.1", "source_ref": "v1.5.1"},
     {"release": "1.5.0", "source_ref": "v1.5.0"},
     {"release": "1.4.3", "source_ref": "v1.4.3"},
     {"release": "1.4.2", "source_ref": "v1.4.2"},

--- a/packages/lazarus/cli_fp.lpk
+++ b/packages/lazarus/cli_fp.lpk
@@ -36,7 +36,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. "/>
-    <Version Major="1" Minor="5" Release="0"/>
+    <Version Major="1" Minor="5" Release="1"/>
     <Files>
       <Item>
         <Filename Value="..\..\src\cli.application.pas"/>

--- a/src/cli.application.pas
+++ b/src/cli.application.pas
@@ -725,8 +725,11 @@ begin
   // Add global flags
   Result.Add('--help');
   Result.Add('-h');
-  Result.Add('--version');
-  Result.Add('-v');
+  if FCurrentCommand = FRootCommand then
+  begin
+    Result.Add('--version');
+    Result.Add('-v');
+  end;
 end;
 
 { ValidateCommand: Checks if all parameters are valid

--- a/src/cli.command.pas
+++ b/src/cli.command.pas
@@ -425,6 +425,7 @@ function TBaseCommand.GetParameterValue(const Flag: string; out Value: string): 
 var
   Param: ICommandParameter;
 begin
+  Value := '';
   Result := False;
   if not Assigned(FParsedParams) then
     Exit;
@@ -432,7 +433,7 @@ begin
   // Find the parameter object for type info
   for Param in FParameters do
   begin
-    if (Param.LongFlag = Flag) or (Param.ShortFlag = Flag) then
+    if SameText(Param.LongFlag, Flag) or SameText(Param.ShortFlag, Flag) then
     begin
       Result := TryGetParameterValue(Param, FParsedParams, Value);
       Exit;

--- a/src/cli.internal.completion.pas
+++ b/src/cli.internal.completion.pas
@@ -90,8 +90,6 @@ begin
 
   if StartsStr(LowerCase(Prefix), '--help') then Suggestions.Add('--help');
   if StartsStr(LowerCase(Prefix), '-h') then Suggestions.Add('-h');
-  if StartsStr(LowerCase(Prefix), '--version') then Suggestions.Add('--version');
-  if StartsStr(LowerCase(Prefix), '-v') then Suggestions.Add('-v');
   if IncludeExtended then
   begin
     if StartsStr(LowerCase(Prefix), '--help-complete') then
@@ -117,7 +115,8 @@ begin
       StartsStr(LowerCase(Prefix), LowerCase(Param.ShortFlag)) then
       Suggestions.Add(Param.ShortFlag);
   end;
-  AddGlobalFlags(Suggestions, Prefix, Command = FRootCommand, False);
+  AddGlobalFlags(Suggestions, Prefix, Command = FRootCommand,
+    Command = FRootCommand);
 end;
 
 procedure TCLICompletionEngine.AddParameterValues(const Suggestions: TStrings;

--- a/src/cli.internal.completion.pas
+++ b/src/cli.internal.completion.pas
@@ -110,7 +110,8 @@ var
 begin
   for Param in Command.Parameters do
   begin
-    if StartsStr(LowerCase(Prefix), LowerCase(Param.LongFlag)) then
+    if (Param.LongFlag <> '') and
+      StartsStr(LowerCase(Prefix), LowerCase(Param.LongFlag)) then
       Suggestions.Add(Param.LongFlag);
     if (Param.ShortFlag <> '') and
       StartsStr(LowerCase(Prefix), LowerCase(Param.ShortFlag)) then
@@ -238,7 +239,8 @@ begin
     Suggestions.Add(SubCommand.Name);
   for Param in Command.Parameters do
   begin
-    Suggestions.Add(Param.LongFlag);
+    if Param.LongFlag <> '' then
+      Suggestions.Add(Param.LongFlag);
     if Param.ShortFlag <> '' then
       Suggestions.Add(Param.ShortFlag);
   end;

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -109,29 +109,29 @@ release v1.5.1 without changing the public facade.
 
 - [x] Inspect the v1.5.0 `main` implementation, tests, docs, version metadata,
   DocKit configuration, and CI workflows.
-- [ ] Add focused failing regressions for case-insensitive descendant lookup,
+- [x] Add focused failing regressions for case-insensitive descendant lookup,
   empty completion suggestions, and named-command version rejection.
 
 ### Phase 2: Surgical runtime fixes
 
-- [ ] Make `TBaseCommand.GetParameterValue` use case-insensitive flag matching
+- [x] Make `TBaseCommand.GetParameterValue` use case-insensitive flag matching
   while preserving miss initialization.
-- [ ] Guard both flag forms independently in every relevant completion path.
-- [ ] Keep version global at application level; reject and avoid suggesting it
+- [x] Guard both flag forms independently in every relevant completion path.
+- [x] Keep version global at application level; reject and avoid suggesting it
   after named-command selection.
 
 ### Checkpoint: Runtime patch
 
-- [ ] Focused regressions fail before the fixes and pass afterward.
-- [ ] Existing v1.5.0 behavior remains covered and passing.
+- [x] Focused regressions fail before the fixes and pass afterward.
+- [x] Existing v1.5.0 behavior remains covered and passing.
 
 ### Phase 3: Documentation and release metadata
 
-- [ ] Correct stale current 1.x wording and label `GetParameterValue` as a
+- [x] Correct stale current 1.x wording and label `GetParameterValue` as a
   protected descendant member in the API reference.
-- [ ] Update authoritative current version locations to 1.5.1, add concise
+- [x] Update authoritative current version locations to 1.5.1, add concise
   changelog/release notes, update roadmap context, and add DocKit v1.5.1.
-- [ ] Preserve historical release notes and tags unchanged.
+- [x] Preserve historical release notes and tags unchanged.
 
 ### Checkpoint: Qualification
 

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -78,3 +78,89 @@ public facade or adding positional-argument semantics.
 | Shell quoting fix creates invalid scripts | Add generated-script inspection and shell syntax tests. |
 | FPC 3.2.2 differences | Use repository runners and CI-equivalent commands on Windows. |
 | Release permissions unavailable | Finish local qualification and report exact remote blocker/actions. |
+
+---
+
+# Implementation Plan: cli-fp v1.5.1 Correctness and Completion Patch
+
+## Overview
+
+Deliver a surgical patch release from the v1.5.0 `main` baseline. Confirm and
+fix only the reported `GetParameterValue`, completion-suggestion, and
+application-version semantics; clarify current documentation; update current
+version metadata and immutable DocKit version history; then qualify and
+release v1.5.1 without changing the public facade.
+
+## Architecture decisions
+
+- Reuse `SameText` and the existing parameter-value lookup conventions rather
+  than introducing a second lookup abstraction.
+- Keep application `--version`/`-v` handling at the application boundary and
+  remove those flags only from selected named-command validation/completion.
+- Keep the existing completion engine and command model intact; add only
+  independent empty-flag guards.
+- Preserve v1.5.0 and older documentation sources as immutable historical
+  releases; make only current documentation and version metadata current for
+  v1.5.1.
+
+## Task list
+
+### Phase 1: Confirm and reproduce
+
+- [x] Inspect the v1.5.0 `main` implementation, tests, docs, version metadata,
+  DocKit configuration, and CI workflows.
+- [ ] Add focused failing regressions for case-insensitive descendant lookup,
+  empty completion suggestions, and named-command version rejection.
+
+### Phase 2: Surgical runtime fixes
+
+- [ ] Make `TBaseCommand.GetParameterValue` use case-insensitive flag matching
+  while preserving miss initialization.
+- [ ] Guard both flag forms independently in every relevant completion path.
+- [ ] Keep version global at application level; reject and avoid suggesting it
+  after named-command selection.
+
+### Checkpoint: Runtime patch
+
+- [ ] Focused regressions fail before the fixes and pass afterward.
+- [ ] Existing v1.5.0 behavior remains covered and passing.
+
+### Phase 3: Documentation and release metadata
+
+- [ ] Correct stale current 1.x wording and label `GetParameterValue` as a
+  protected descendant member in the API reference.
+- [ ] Update authoritative current version locations to 1.5.1, add concise
+  changelog/release notes, update roadmap context, and add DocKit v1.5.1.
+- [ ] Preserve historical release notes and tags unchanged.
+
+### Checkpoint: Qualification
+
+- [ ] Framework, generator, completion, example, cleanup, golden,
+  compile-smoke, docs, DocKit, and diff checks pass where supported.
+- [ ] Code review finds no required correctness, security, architecture, or
+  compatibility issues.
+
+### Phase 4: Remote release
+
+- [ ] Push `release/v1.5.1` and open the PR.
+- [ ] Observe green Linux and Windows CI, then stop for explicit merge
+  authorization if repository safety requires it.
+- [ ] After authorization, squash merge, tag, publish the release, verify
+  post-merge/tag CI, deploy/live-check Pages, and report final state.
+
+## Explicitly deferred
+
+Positional arguments, `--` terminator semantics, per-command versioning,
+typed getters, execution-context redesign, the major `TCLIApplication` split,
+renderer extraction, help architecture redesign, exception hierarchy changes,
+deprecated API removal, presentation/data separation, Unicode display-width
+redesign, historical archive reorganization, sanitizer policy expansion, and
+new dependencies remain out of scope.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Removing command-level version suggestions changes completion output | Keep application-level handling unchanged and add explicit root/named tests. |
+| A one-flag parameter regresses completion | Test short-only, long-only, and two-flag definitions through the real engine. |
+| Current-version edits rewrite history | Limit edits to active metadata/current docs and preserve v1.5.0 release sources. |

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -135,9 +135,9 @@ release v1.5.1 without changing the public facade.
 
 ### Checkpoint: Qualification
 
-- [ ] Framework, generator, completion, example, cleanup, golden,
+- [x] Framework, generator, completion, example, cleanup, golden,
   compile-smoke, docs, DocKit, and diff checks pass where supported.
-- [ ] Code review finds no required correctness, security, architecture, or
+- [x] Code review finds no required correctness, security, architecture, or
   compatibility issues.
 
 ### Phase 4: Remote release

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -12,11 +12,11 @@
 ## cli-fp v1.5.1
 
 - [x] Confirm v1.5.0 baseline findings
-- [ ] Add failing regression tests
-- [ ] Fix case-insensitive `GetParameterValue`
-- [ ] Prevent blank completion suggestions
-- [ ] Correct command-level version semantics
-- [ ] Update current docs, changelog, release notes, roadmap, and DocKit metadata
+- [x] Add failing regression tests
+- [x] Fix case-insensitive `GetParameterValue`
+- [x] Prevent blank completion suggestions
+- [x] Correct command-level version semantics
+- [x] Update current docs, changelog, release notes, roadmap, and DocKit metadata
 - [ ] Run local qualification and code review
 - [ ] Push branch and create PR
 - [ ] Observe CI and request merge authorization at the safety boundary

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -8,3 +8,16 @@
 - [x] Version/changelog/roadmap/DocKit metadata
 - [x] Local qualification and review
 - [ ] PR/merge/tag/release/Pages verification
+
+## cli-fp v1.5.1
+
+- [x] Confirm v1.5.0 baseline findings
+- [ ] Add failing regression tests
+- [ ] Fix case-insensitive `GetParameterValue`
+- [ ] Prevent blank completion suggestions
+- [ ] Correct command-level version semantics
+- [ ] Update current docs, changelog, release notes, roadmap, and DocKit metadata
+- [ ] Run local qualification and code review
+- [ ] Push branch and create PR
+- [ ] Observe CI and request merge authorization at the safety boundary
+- [ ] Merge, tag, publish, deploy, live-verify, and report release

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -17,7 +17,7 @@
 - [x] Prevent blank completion suggestions
 - [x] Correct command-level version semantics
 - [x] Update current docs, changelog, release notes, roadmap, and DocKit metadata
-- [ ] Run local qualification and code review
+- [x] Run local qualification and code review
 - [ ] Push branch and create PR
 - [ ] Observe CI and request merge authorization at the safety boundary
 - [ ] Merge, tag, publish, deploy, live-verify, and report release

--- a/tests/testcase.pas
+++ b/tests/testcase.pas
@@ -96,6 +96,7 @@ type
 
     // 10.x - v1.5.1 Correctness and Completion Patch
     procedure Test_10_1_DirectParameterLookupIsCaseInsensitive;
+    procedure Test_10_2_CompletionOmitsEmptyParameterFlags;
   end;
 
 implementation
@@ -1672,6 +1673,40 @@ begin
   finally
     Parsed.Free;
     Cmd.Free;
+  end;
+end;
+
+procedure TCLIFrameworkTests.Test_10_2_CompletionOmitsEmptyParameterFlags;
+var
+  App: TCLIApplication;
+  Cmd: TTestCommand;
+  Candidates: TStringList;
+begin
+  App := TCLIApplication.Create('TestApp', '1.5.1');
+  Cmd := TTestCommand.Create('test', 'Test command');
+  try
+    Cmd.AddStringParameter('-n', '', 'Short-only parameter');
+    Cmd.AddStringParameter('', '--name', 'Long-only parameter');
+    Cmd.AddStringParameter('-b', '--both', 'Parameter with both flags');
+    App.RegisterCommand(Cmd);
+
+    Candidates := App.TestComplete(MakeArgs(['test', '']));
+    try
+      AssertEquals('Completion should not emit an empty flag candidate', -1,
+        Candidates.IndexOf(''));
+      AssertTrue('Short-only parameters should be completed',
+        Candidates.IndexOf('-n') >= 0);
+      AssertTrue('Long-only parameters should be completed',
+        Candidates.IndexOf('--name') >= 0);
+      AssertTrue('Both parameter flags should be completed',
+        Candidates.IndexOf('-b') >= 0);
+      AssertTrue('Both parameter long flags should be completed',
+        Candidates.IndexOf('--both') >= 0);
+    finally
+      Candidates.Free;
+    end;
+  finally
+    App.Free;
   end;
 end;
 

--- a/tests/testcase.pas
+++ b/tests/testcase.pas
@@ -1706,6 +1706,18 @@ begin
     finally
       Candidates.Free;
     end;
+
+    Candidates := App.TestComplete(MakeArgs(['test', '--']));
+    try
+      AssertEquals('Flag-prefix completion should not emit an empty candidate',
+        -1, Candidates.IndexOf(''));
+      AssertTrue('Long-only parameters should complete after a long prefix',
+        Candidates.IndexOf('--name') >= 0);
+      AssertTrue('Both parameters should complete after a long prefix',
+        Candidates.IndexOf('--both') >= 0);
+    finally
+      Candidates.Free;
+    end;
   finally
     App.Free;
   end;

--- a/tests/testcase.pas
+++ b/tests/testcase.pas
@@ -97,6 +97,7 @@ type
     // 10.x - v1.5.1 Correctness and Completion Patch
     procedure Test_10_1_DirectParameterLookupIsCaseInsensitive;
     procedure Test_10_2_CompletionOmitsEmptyParameterFlags;
+    procedure Test_10_3_ApplicationOnlyVersionFlags;
   end;
 
 implementation
@@ -1706,6 +1707,61 @@ begin
       Candidates.Free;
     end;
   finally
+    App.Free;
+  end;
+end;
+
+procedure TCLIFrameworkTests.Test_10_3_ApplicationOnlyVersionFlags;
+var
+  App: TCLIApplication;
+  Cmd: TRecordingCommand;
+  Output: TStringList;
+  Candidates: TStringList;
+begin
+  App := TCLIApplication.Create('TestApp', '1.5.1');
+  Cmd := TRecordingCommand.Create('test', 'Test command');
+  Output := TStringList.Create;
+  try
+    App.RegisterCommand(Cmd);
+
+    AssertEquals('Application-level long version should succeed', 0,
+      App.TestExecuteAndCapture(MakeArgs(['--version']), Output));
+    AssertTrue('Application-level long version should be reported',
+      Pos('TestApp version 1.5.1', Output.Text) > 0);
+
+    Output.Clear;
+    AssertEquals('Application-level short version should succeed', 0,
+      App.TestExecuteAndCapture(MakeArgs(['-v']), Output));
+    AssertTrue('Application-level short version should be reported',
+      Pos('TestApp version 1.5.1', Output.Text) > 0);
+
+    Output.Clear;
+    AssertEquals('Named-command long version should be rejected', 1,
+      App.TestExecuteAndCapture(MakeArgs(['test', '--version']), Output));
+    AssertEquals('Rejected named-command version must not execute', 0,
+      Cmd.ExecuteCount);
+
+    Output.Clear;
+    AssertEquals('Named-command short version should be rejected', 1,
+      App.TestExecuteAndCapture(MakeArgs(['test', '-v']), Output));
+    AssertEquals('Rejected named-command short version must not execute', 0,
+      Cmd.ExecuteCount);
+
+    Candidates := App.TestComplete(MakeArgs(['test', '']));
+    try
+      AssertEquals('Named-command completion should omit --version', -1,
+        Candidates.IndexOf('--version'));
+      AssertEquals('Named-command completion should omit -v', -1,
+        Candidates.IndexOf('-v'));
+      AssertTrue('Named-command completion should retain --help',
+        Candidates.IndexOf('--help') >= 0);
+      AssertTrue('Named-command completion should retain -h',
+        Candidates.IndexOf('-h') >= 0);
+    finally
+      Candidates.Free;
+    end;
+  finally
+    Output.Free;
     App.Free;
   end;
 end;

--- a/tests/testcase.pas
+++ b/tests/testcase.pas
@@ -93,6 +93,9 @@ type
     procedure Test_9_7_HelpExtraArgumentsAndValueMiss;
     procedure Test_9_8_EnumValuesMayContainSpaces;
     procedure Test_9_9_TerminalTextSanitization;
+
+    // 10.x - v1.5.1 Correctness and Completion Patch
+    procedure Test_10_1_DirectParameterLookupIsCaseInsensitive;
   end;
 
 implementation
@@ -1633,6 +1636,42 @@ begin
   finally
     Output.Free;
     App.Free;
+  end;
+end;
+
+procedure TCLIFrameworkTests.Test_10_1_DirectParameterLookupIsCaseInsensitive;
+var
+  Cmd: TTestCommand;
+  Parsed: TStringList;
+  Value: string;
+begin
+  Cmd := TTestCommand.Create('test', 'Test command');
+  Parsed := TStringList.Create;
+  try
+    Parsed.CaseSensitive := False;
+    Parsed.Add('-n=Ada');
+    Cmd.AddStringParameter('-n', '--name', 'Name');
+    Cmd.SetParsedParams(Parsed);
+
+    AssertTrue('Direct lookup should find an exact long flag',
+      Cmd.TestGetParameterValue('--name', Value));
+    AssertEquals('Exact long lookup should return its value', 'Ada', Value);
+    AssertTrue('Direct lookup should ignore long flag case',
+      Cmd.TestGetParameterValue('--NAME', Value));
+    AssertEquals('Case-insensitive long lookup should return its value',
+      'Ada', Value);
+    AssertTrue('Direct lookup should ignore short flag case',
+      Cmd.TestGetParameterValue('-N', Value));
+    AssertEquals('Case-insensitive short lookup should return its value',
+      'Ada', Value);
+
+    Value := 'stale';
+    AssertFalse('Missing direct lookup should return False',
+      Cmd.TestGetParameterValue('--missing', Value));
+    AssertEquals('Missing direct lookup should clear its output', '', Value);
+  finally
+    Parsed.Free;
+    Cmd.Free;
   end;
 end;
 


### PR DESCRIPTION
## Summary\n- Make direct TBaseCommand.GetParameterValue lookup case-insensitive and deterministic on misses.\n- Prevent empty completion candidates for one-form parameters.\n- Keep --version and -v application-level; reject and omit them for named commands.\n- Update active docs, release notes, roadmap, package metadata, and DocKit versions for v1.5.1.\n\n## Validation\n- Windows framework suite: 60 tests, 0 errors, 0 failures.\n- Windows generator unit, golden, operations, and compile-smoke tests pass.\n- Windows eight-example cleanup smoke passes.\n- Lazarus package build passes with package version 1.5.1.\n- DocKit check and audit pass; shell and PowerShell syntax checks pass.\n\n## Compatibility\nNo public facade redesign. Positional arguments, -- terminator, per-command versions, typed getters, and other deferred work remain out of scope.\n\n## Merge\nRecommend squash merge after required Linux and Windows CI pass. Do not merge until explicitly authorized.