### PR TITLE
Release cli-fp v1.5.2 — Safety & Documentation Corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-09-12
+
+### Fixed
+
+- Progress captions now use the same terminal-text sanitization as normal
+  console output, removing caller-provided NUL and ESC characters while
+  retaining the renderer's carriage-return redraw behavior.
+- Corrected portable path construction and runnable usage guidance in the
+  LongRunningOpDemo and ErrorHandlingDemo examples.
+- Added the standard `{$J-}` compiler-safety directive to ProgressDemo.
+- Corrected the current completion documentation link and made
+  `example-bin/README.md` consistent with the repository's source-only binary
+  policy.
+
 ## [1.5.1] - 2026-09-12
 
 ### Fixed
@@ -529,7 +543,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README with quick start guide
 - System requirements and compatibility information
 
-[Unreleased]: https://github.com/ikelaiah/cli-fp/compare/v1.5.1...HEAD
+[Unreleased]: https://github.com/ikelaiah/cli-fp/compare/v1.5.2...HEAD
+[1.5.2]: https://github.com/ikelaiah/cli-fp/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/ikelaiah/cli-fp/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/ikelaiah/cli-fp/compare/v1.4.3...v1.5.0
 [1.4.3]: https://github.com/ikelaiah/cli-fp/compare/v1.4.2...v1.4.3

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Lazarus](https://img.shields.io/badge/Lazarus-package-60A5FA.svg)](https://github.com/ikelaiah/cli-fp/blob/main/packages/lazarus/cli_fp.lpk)
 ![Supports Windows](https://img.shields.io/badge/support-Windows-F59E0B?logo=Windows)
 ![Supports Linux](https://img.shields.io/badge/support-Linux-F59E0B?logo=Linux)
-[![Version](https://img.shields.io/badge/version-1.5.1-8B5CF6.svg)](https://github.com/ikelaiah/cli-fp/blob/main/CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.5.2-8B5CF6.svg)](https://github.com/ikelaiah/cli-fp/blob/main/CHANGELOG.md)
 [![Documentation](https://img.shields.io/badge/Docs-Website-brightgreen.svg)](https://ikelaiah.github.io/cli-fp/)
 [![Tests](https://github.com/ikelaiah/cli-fp/actions/workflows/tests.yml/badge.svg)](https://github.com/ikelaiah/cli-fp/actions/workflows/tests.yml)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -174,6 +174,18 @@ definitions and unsafe edge cases fail predictably.
 runtime shape while lookup, completion, and built-in version boundaries are
 consistent and predictable.
 
+## v1.5.2 — Safety and Documentation Corrections (completed 2026-09-12)
+
+- Sanitize caller-controlled progress captions using the established terminal
+  text policy without changing renderer redraw semantics.
+- Correct runnable example guidance, portable demo path construction, the
+  ProgressDemo compiler directive, and directly related current documentation.
+- Keep current DocKit metadata ready for the immutable `v1.5.2` release
+  snapshot.
+
+**Maintenance outcome:** progress output and example documentation remain safe,
+portable, and truthful without changing the v1.x command model or public API.
+
 ## v1.6.0 — Finish the Application Core Boundaries
 
 - Continue internal architecture cleanup without changing the public facade.

--- a/docs/RELEASE_NOTES_v1.5.2.md
+++ b/docs/RELEASE_NOTES_v1.5.2.md
@@ -1,0 +1,31 @@
+# cli-fp v1.5.2 — Safety and Documentation Corrections
+
+cli-fp v1.5.2 is a focused maintenance release. It keeps the existing 1.x
+command model and public API unchanged.
+
+## Fixed
+
+- `TProgressIndicator.RenderText` now applies the established terminal-text
+  sanitization policy to caller-controlled render text. NUL and ESC characters
+  are removed, while the renderer's own carriage-return redraw remains intact.
+- LongRunningOpDemo documents a working invocation with its required
+  `--input` option and uses portable path construction.
+- ErrorHandlingDemo explains that its simulated validation results vary per
+  run and uses portable path construction.
+- ProgressDemo now uses the project's standard `{$J-}` compiler-safety
+  directive.
+- The completion-testing index links to the current completion documentation,
+  and `example-bin/README.md` now accurately describes the source-only binary
+  policy and all canonical examples.
+
+## Compatibility
+
+Normal v1.5.1 applications remain source- and behavior-compatible. No parser
+grammar, command ownership, completion architecture, public API, or exception
+hierarchy changes are included.
+
+## Deferred work
+
+The planned v1.6.0 internal extraction and application-core work remains
+deferred. Parser grammar changes and public API redesign remain out of scope
+for this patch release.

--- a/docs/completion-testing/README.md
+++ b/docs/completion-testing/README.md
@@ -11,8 +11,8 @@
 
 This directory contains current user guides plus historical completion test and
 development records. The dated test reports describe the implementation at the
-time they were written; use the user guides and the
-[main user manual](../user-manual.md#bash-completion) for current behavior.
+time they were written; use the user guides and the current
+[completion documentation](../completion.md) for current behavior.
 
 ## Files
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -2,7 +2,7 @@
 
 [How do I...?](how-to.md) · [Commands](commands.md) · [Options](options.md)
 
-These are current v1.5.1 boundaries verified against the public source and
+These are current v1.5.2 boundaries verified against the public source and
 tests. They are intentionally easy to find so a limitation does not look like
 an undocumented feature.
 

--- a/docs/project.md
+++ b/docs/project.md
@@ -1,8 +1,8 @@
 # Contributing and support
 
 `cli-fp` is a small open-source framework maintained around a deliberately
-small public API. v1.5.1 is a correctness and completion patch: the supported
-runtime remains the class-based API described in these guides.
+small public API. v1.5.2 is a safety and documentation correction patch: the
+supported runtime remains the class-based API described in these guides.
 
 ## Supported environments
 

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -1,6 +1,6 @@
 # cli-fp user manual
 
-This page remains as a stable starting point for existing links. The v1.5.1
+This page remains as a stable starting point for existing links. The v1.5.2
 documentation is organized by the job you want to do rather than as one long
 manual.
 

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,7 +1,8 @@
 {
   "schema_version": 1,
-  "current": "1.5.1",
+  "current": "1.5.2",
   "versions": [
+    {"release": "1.5.2", "source_ref": "v1.5.2"},
     {"release": "1.5.1", "source_ref": "v1.5.1"},
     {"release": "1.5.0", "source_ref": "v1.5.0"},
     {"release": "1.4.3", "source_ref": "v1.4.3"},

--- a/example-bin/README.md
+++ b/example-bin/README.md
@@ -1,17 +1,19 @@
 # Example Binaries
 
-This directory contains pre-compiled example executables demonstrating the cli-fp framework.
+This directory tracks generated completion-script examples. Precompiled example
+executables are not committed; local example builds place their output here.
 
 ## Available Examples
 
-### Core Examples
-- **SimpleDemo.exe** - Basic CLI with parameters, spinner, and colored output
-- **ColorDemo.exe** - Professional colored output with decorative formatting
-- **ProgressDemo.exe** - Spinner and progress bar demonstrations
-- **RootCommandDemo.exe** - Command-less root execution with optional named commands
-- **SubCommandDemo.exe** - Hierarchical commands (git-like structure)
-- **ErrorHandlingDemo.exe** - Error handling patterns
-- **LongRunningOpDemo.exe** - Advanced parameter types
+### Canonical Examples
+- **QuickStartDemo** - Smallest root-command CLI
+- **SimpleDemo** - Basic CLI with parameters, spinner, and colored output
+- **ColorDemo** - Professional colored output with decorative formatting
+- **ProgressDemo** - Spinner and progress bar demonstrations
+- **RootCommandDemo** - Command-less root execution with optional named commands
+- **SubCommandDemo** - Hierarchical commands (git-like structure)
+- **ErrorHandlingDemo** - Error handling patterns
+- **LongRunningOpDemo** - Advanced parameter types
 
 ## Shell Completion Scripts
 
@@ -56,6 +58,7 @@ Each example includes `--help` to show usage:
 
 ```bash
 ./SimpleDemo.exe --help
+./QuickStartDemo.exe --name Gus
 ./RootCommandDemo.exe --name Gus
 ./SubCommandDemo.exe repo --help
 ./ProgressDemo.exe process --help
@@ -65,6 +68,7 @@ Each example includes `--help` to show usage:
 
 Example source code is located in the `examples/` directory:
 - `examples/SimpleDemo/`
+- `examples/QuickStartDemo/`
 - `examples/ColorDemo/`
 - `examples/ProgressDemo/`
 - `examples/RootCommandDemo/`
@@ -87,19 +91,20 @@ The executable will be placed in `example-bin/`.
 
 - `*_completion.bash` files - Bash completion scripts
 - `*_completion.ps1` files - PowerShell completion scripts
-- `lib/` - Shared compiled units (can be ignored)
+- locally-built executables and `lib/` units (ignored by Git)
 
-**Note:** Pre-compiled binaries are no longer included in this directory. Users should compile examples from source using the build scripts in the repository root (`compile-all-examples.ps1` or `compile-all-examples.sh`).
+Build examples from source with `compile-all-examples.ps1` or
+`compile-all-examples.sh`. Generated executables remain local and can be
+removed with the matching cleanup script.
 
 ## Documentation
 
 For detailed completion documentation, see:
-- [docs/completion-testing/](../docs/completion-testing/) - Testing documentation
-- [docs/completion-testing/BASH_COMPLETION_GUIDE.md](../docs/completion-testing/BASH_COMPLETION_GUIDE.md) - User guide
+- [docs/completion.md](../docs/completion.md) - Completion usage
+- [docs/completion-testing/](../docs/completion-testing/) - Historical testing documentation
 
 ## Notes
 
-- These are pre-built binaries for convenience
 - Source code in `examples/` is the authoritative version
-- Rebuild after framework changes
+- Rebuild locally after framework changes
 - Completion scripts should be regenerated after rebuilding

--- a/examples/ErrorHandlingDemo/ErrorHandlingDemo.lpr
+++ b/examples/ErrorHandlingDemo/ErrorHandlingDemo.lpr
@@ -9,34 +9,15 @@
   3. Colored console output
   4. Basic command structure
 
-  How to run (stop on error):
+  How to run (stop at the first simulated failure):
 
-  $ ErrorHandlingDemo.exe validate -p z:\fake_path -s true
-  Validating z:\fake_path\file1.txt... OK
-  Validating z:\fake_path\file2.txt... OK
-  Validating z:\fake_path\file3.txt... OK
-  Validating z:\fake_path\file4.txt... OK
-  Validating z:\fake_path\file5.txt... OK
-  Validating z:\fake_path\file6.txt... OK
-  Validating z:\fake_path\file7.txt... OK
-  Validating z:\fake_path\file8.txt... OK
-  Validating z:\fake_path\file9.txt... ERROR: Demo validation failed for: z:\fake_path\file9.txt
-  Stopping due to error (--stop-on-error)
+  $ ErrorHandlingDemo.exe validate --path . --stop-on-error
 
-  How to run (don't stop on error):
-
-  $ ErrorHandlingDemo.exe validate -p z:\fake_path -s false
-  Validating z:\fake_path\file1.txt... OK
-  Validating z:\fake_path\file2.txt... OK
-  Validating z:\fake_path\file3.txt... OK
-  Validating z:\fake_path\file4.txt... OK
-  Validating z:\fake_path\file5.txt... OK
-  Validating z:\fake_path\file6.txt... OK
-  Validating z:\fake_path\file7.txt... OK
-  Validating z:\fake_path\file8.txt... OK
-  Validating z:\fake_path\file9.txt... ERROR: Demo validation failed for: z:\fake_path\file9.txt
-  Validating z:\fake_path\file10.txt... OK
-  Validation complete with 1 errors
+  The demonstration intentionally randomizes validation results for ten
+  simulated files. The failing file and exact output vary between runs.
+  With --stop-on-error, processing stops at the first failure; without it,
+  every simulated file is processed and the command returns a non-zero exit
+  code if one or more validations fail.
 }
 program ErrorHandlingDemo;
 
@@ -106,16 +87,9 @@ begin
     try
       // In a real app, you would scan the directory here
       // This is just a simulation with hardcoded files
-      Files.Add(Path + '\file1.txt');
-      Files.Add(Path + '\file2.txt');
-      Files.Add(Path + '\file3.txt');
-      Files.Add(Path + '\file4.txt');
-      Files.Add(Path + '\file5.txt');
-      Files.Add(Path + '\file6.txt');
-      Files.Add(Path + '\file7.txt');
-      Files.Add(Path + '\file8.txt');
-      Files.Add(Path + '\file9.txt');
-      Files.Add(Path + '\file10.txt');
+      for i := 1 to 10 do
+        Files.Add(IncludeTrailingPathDelimiter(Path) +
+          Format('file%d.txt', [i]));
 
       // Process each file with error handling
       for i := 0 to Files.Count - 1 do

--- a/examples/LongRunningOpDemo/LongRunningOpDemo.lpr
+++ b/examples/LongRunningOpDemo/LongRunningOpDemo.lpr
@@ -12,21 +12,13 @@
   How to run:
   Option 1 - Basic usage with progress bar only:
   ```
-  $ LongRunningOpDemo.exe process
-  Finding files...
-
-  [====================] 100% All files processed successfully!
+  $ LongRunningOpDemo.exe process --input .
   ```
+  The --input path is required; this demonstration uses the current directory.
 
   Option 2 - Verbose mode shows detailed progress:
   ```
-  $ LongRunningOpDemo.exe process -v true
-  Finding files...
-
-  Processing: file1.txt
-  [=======             ]  33% Processing: file2.txt
-  [=============       ]  67% Processing: file3.txt
-  [====================] 100% All files processed successfully!
+  $ LongRunningOpDemo.exe process --input . --verbose
   ```
 }
 program LongRunningOpDemo;
@@ -141,7 +133,8 @@ type
         begin
           Spinner.Update(0);
           Sleep(300);  // Simulate searching
-          Files.Add(Format('%s\file%d.txt', [InputDir, i]));
+          Files.Add(IncludeTrailingPathDelimiter(InputDir) +
+            Format('file%d.txt', [i]));
         end;
       finally
         Spinner.Stop;

--- a/examples/ProgressDemo/ProgressDemo.lpr
+++ b/examples/ProgressDemo/ProgressDemo.lpr
@@ -1,6 +1,6 @@
 program ProgressDemo;
 
-{$mode objfpc}{$H+}
+{$mode objfpc}{$H+}{$J-}
 
 { This demo shows how to use progress indicators (spinner and progress bar)
   in a CLI application. It demonstrates:

--- a/packages/lazarus/cli_fp.lpk
+++ b/packages/lazarus/cli_fp.lpk
@@ -36,7 +36,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. "/>
-    <Version Major="1" Minor="5" Release="1"/>
+    <Version Major="1" Minor="5" Release="2"/>
     <Files>
       <Item>
         <Filename Value="..\..\src\cli.application.pas"/>

--- a/src/cli.progress.pas
+++ b/src/cli.progress.pas
@@ -13,7 +13,7 @@ unit CLI.Progress;
 interface
 
 uses
-  Classes, SysUtils, CLI.Interfaces, CLI.Console;
+  Classes, SysUtils, CLI.Interfaces, CLI.Console, CLI.Internal.Text;
 
 const
   MaxProgressBarWidth = 200;
@@ -147,11 +147,13 @@ end;
 
 procedure TProgressIndicator.RenderText(const Text: string);
 var
+  SanitizedText: string;
   CurrentLength: Integer;
 begin
-  CurrentLength := Length(Text);
+  SanitizedText := SanitizeTerminalText(Text);
+  CurrentLength := Length(SanitizedText);
   Write(#13);
-  Write(Text);
+  Write(SanitizedText);
   if CurrentLength < FLastRenderLength then
     Write(StringOfChar(' ', FLastRenderLength - CurrentLength));
   FLastRenderLength := CurrentLength;

--- a/tests/testcase.pas
+++ b/tests/testcase.pas
@@ -98,6 +98,9 @@ type
     procedure Test_10_1_DirectParameterLookupIsCaseInsensitive;
     procedure Test_10_2_CompletionOmitsEmptyParameterFlags;
     procedure Test_10_3_ApplicationOnlyVersionFlags;
+
+    // 11.x - v1.5.2 Safety and Documentation Corrections
+    procedure Test_11_1_ProgressCaptionTerminalSanitization;
   end;
 
 implementation
@@ -1775,6 +1778,53 @@ begin
   finally
     Output.Free;
     App.Free;
+  end;
+end;
+
+procedure TCLIFrameworkTests.Test_11_1_ProgressCaptionTerminalSanitization;
+var
+  Progress: TProgressBar;
+  SavedOutput: Text;
+  OutputFileName: string;
+  Stream: TFileStream;
+  Captured: string;
+begin
+  OutputFileName := GetTempFileName(GetTempDir, 'cli-fp-progress-');
+  SavedOutput := Output;
+  AssignFile(Output, OutputFileName);
+  Rewrite(Output);
+  try
+    Progress := TProgressBar.Create(1, 1);
+    try
+      Progress.Start;
+      Progress.Update(1, 'caption' + #27 + '[31m' + #0);
+      Progress.Stop;
+    finally
+      Progress.Free;
+    end;
+  finally
+    Close(Output);
+    Output := SavedOutput;
+  end;
+
+  try
+    Stream := TFileStream.Create(OutputFileName, fmOpenRead or fmShareDenyWrite);
+    try
+      SetLength(Captured, Stream.Size);
+      if Stream.Size > 0 then
+        Stream.ReadBuffer(Captured[1], Stream.Size);
+    finally
+      Stream.Free;
+    end;
+
+    AssertEquals('Progress rendering must retain its redraw carriage return',
+      #13, Captured[1]);
+    AssertTrue('Progress captions must not emit ESC', Pos(#27, Captured) = 0);
+    AssertTrue('Progress captions must not emit NUL', Pos(#0, Captured) = 0);
+    AssertTrue('Progress captions should retain safe text',
+      Pos('caption[31m', Captured) > 0);
+  finally
+    DeleteFile(OutputFileName);
   end;
 end;
 


### PR DESCRIPTION
## Summary
- sanitize caller-controlled progress text while preserving internal redraw CR
- correct portable, runnable demo documentation and completion link
- update v1.5.2 release metadata and DocKit registry

## Local qualification
- framework: 61 tests passed
- Windows example build/cleanup smoke: 8 examples passed
- generator unit, golden, operations, and compile-smoke tests passed
- Lazarus package build passed in a clean checkout
- git diff --check passed

No v1.6.0 or public API work is included.